### PR TITLE
lib: add `Message` data types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,12 @@ pub enum Error {
     InvalidDenomination((Denomination, u8)),
     InvalidFailureCode(u8),
     InvalidStatusCode(u8),
+    InvalidMessageId(u8),
+    InvalidConfId(u8),
+    InvalidFuncId(u8),
+    InvalidMessageType(u8),
+    InvalidMessageLen((usize, usize)),
+    InvalidMessageDataLen((usize, usize)),
 }
 
 impl fmt::Display for Error {
@@ -24,6 +30,17 @@ impl fmt::Display for Error {
             ),
             Self::InvalidFailureCode(err) => write!(f, "invalid failure code: {err}"),
             Self::InvalidStatusCode(err) => write!(f, "invalid status code: {err}"),
+            Self::InvalidMessageId(err) => write!(f, "invalid message ID: {err}"),
+            Self::InvalidConfId(err) => write!(f, "invalid conf ID: {err}"),
+            Self::InvalidFuncId(err) => write!(f, "invalid func ID: {err}"),
+            Self::InvalidMessageType(err) => write!(f, "invalid message type: {err}"),
+            Self::InvalidMessageLen((have, exp)) => {
+                write!(f, "invalid message length, have: {have}, expected: {exp}")
+            }
+            Self::InvalidMessageDataLen((have, exp)) => write!(
+                f,
+                "invalid message data length, have: {have}, expected: {exp}"
+            ),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,12 @@ mod bill_acceptor_state;
 mod denomination;
 mod error;
 mod failure_code;
+mod message;
 mod status_code;
 
 pub use bill_acceptor_state::*;
 pub use denomination::*;
 pub use error::*;
 pub use failure_code::*;
+pub use message::*;
 pub use status_code::*;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,0 +1,223 @@
+use std::{fmt, mem};
+
+use crate::{Error, Result};
+
+mod conf_id;
+mod func_id;
+mod message_data;
+mod message_id;
+mod message_type;
+
+pub use conf_id::*;
+pub use func_id::*;
+pub use message_data::*;
+pub use message_id::*;
+pub use message_type::*;
+
+/// Maximum length of the [Message].
+pub const MAX_LEN: usize = u16::MAX as usize;
+/// Minimum length of the [Message].
+pub const MIN_LEN: usize = Message::meta_len() + MessageData::meta_len();
+
+/// Represents the generic message format for JCM host-device communication.
+///
+/// Message format:
+///
+/// Field name  | ID | Length | Data
+/// ------------|----|--------|---------
+/// Size (byte) | 1  | 2      | Variable
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Message {
+    id: MessageId,
+    data: MessageData,
+}
+
+impl Message {
+    /// Creates a new [Message].
+    pub const fn new() -> Self {
+        Self {
+            id: MessageId::Message,
+            data: MessageData::new(),
+        }
+    }
+
+    /// Gets the [MessageId] of the [Message].
+    pub const fn id(&self) -> MessageId {
+        self.id
+    }
+
+    /// Gets a reference to the [MessageData] of the [Message].
+    pub const fn data(&self) -> &MessageData {
+        &self.data
+    }
+
+    /// Sets the [MessageData] of the [Message].
+    pub fn set_data(&mut self, data: MessageData) {
+        self.data = data;
+    }
+
+    /// Builder function that sets the [MessageData] of the [Message].
+    pub fn with_data(mut self, data: MessageData) -> Self {
+        self.set_data(data);
+        self
+    }
+
+    /// Gets the length of the [Message].
+    pub fn len(&self) -> usize {
+        Self::meta_len() + self.data.len()
+    }
+
+    pub(crate) const fn meta_len() -> usize {
+        MessageId::len() + mem::size_of::<u16>()
+    }
+
+    /// Gets whether the [Message] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+impl From<&Message> for Vec<u8> {
+    fn from(val: &Message) -> Self {
+        let len = (val.data.len() as u16).to_be_bytes();
+
+        [val.id as u8, len[0], len[1]]
+            .into_iter()
+            .chain(Vec::<u8>::from(val.data()))
+            .collect()
+    }
+}
+
+impl From<Message> for Vec<u8> {
+    fn from(val: Message) -> Self {
+        let len = (val.data.len() as u16).to_be_bytes();
+
+        [val.id as u8, len[0], len[1]]
+            .into_iter()
+            .chain(Vec::<u8>::from(val.data))
+            .collect()
+    }
+}
+
+impl TryFrom<&[u8]> for Message {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        let len = val.len();
+        if len < MIN_LEN {
+            Err(Error::InvalidMessageLen((len, MIN_LEN)))
+        } else {
+            let id = MessageId::try_from(val[0])?;
+
+            let data_len = u16::from_be_bytes([val[1], val[2]]) as usize;
+            if data_len > len {
+                Err(Error::InvalidMessageDataLen((
+                    data_len,
+                    len - Self::meta_len(),
+                )))
+            } else {
+                let data = MessageData::try_from(&val[3..(3 + data_len)])?;
+
+                Ok(Self { id, data })
+            }
+        }
+    }
+}
+
+impl fmt::Display for Message {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""id": {},"#, self.id)?;
+        write!(f, r#""data": {}"#, self.data)?;
+        write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_message() -> Result<()> {
+        let raw: [u8; 7] = [
+            // message ID
+            0x12,
+            // length
+            0x00, 0x04,
+            // message data
+            //     conf ID
+            0x10,
+            //     UID
+            0x00,
+            //     message type
+            0x00,
+            //     func ID
+            0x00,
+            //     additional data (none)
+        ];
+
+        let exp = Message::new();
+        let msg = Message::try_from(raw.as_ref())?;
+
+        assert_eq!(msg, exp);
+
+        Ok(())
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_message_with_data() -> Result<()> {
+        let raw: [u8; 15] = [
+            // message ID
+            0x12,
+            // length
+            0x00, 0x0c,
+            // message data
+            //     conf ID
+            0x10,
+            //     UID
+            0x00,
+            //     message type
+            0x00,
+            //     func ID
+            0x00,
+            //     additional data
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ];
+
+        let exp = Message::new().with_data(MessageData::new().with_additional(&raw[7..]));
+        let msg = Message::try_from(raw.as_ref())?;
+
+        assert_eq!(msg, exp);
+
+        Ok(())
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_message_with_invalid_data() -> Result<()> {
+        let raw: [u8; 15] = [
+            // message ID
+            0x12,
+            // length - longer than the raw message buffer
+            0x00, 0xff,
+            // message data
+            //     conf ID
+            0x10,
+            //     UID
+            0x00,
+            //     message type
+            0x00,
+            //     func ID
+            0x00,
+            //     additional data
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ];
+
+        assert!(Message::try_from(raw.as_ref()).is_err());
+
+        Ok(())
+    }
+}

--- a/src/message/conf_id.rs
+++ b/src/message/conf_id.rs
@@ -1,0 +1,125 @@
+use std::{fmt, mem};
+
+use crate::{Error, Result};
+
+const ACCEPTOR: u8 = 0x10;
+const ACCEPTOR_RECYCLER: u8 = 0x11;
+const ACCEPTOR_ESCROW: u8 = 0x12;
+const ACCEPTOR_RECYCLER_ESCROW: u8 = 0x18;
+const RESERVED: u8 = 0xff;
+
+/// Represents the JCM device configuration ID.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConfId {
+    /// Only the primary `acceptor` feature.
+    Acceptor = ACCEPTOR,
+    /// Primary acceptor feature, and secondary recycler feature.
+    AcceptorRecycler = ACCEPTOR_RECYCLER,
+    /// Primary acceptor feature, and secondary escrow feature.
+    AcceptorEscrow = ACCEPTOR_ESCROW,
+    /// Primary acceptor feature, and secondary recycler + escrow features.
+    AcceptorRecyclerEscrow = ACCEPTOR_RECYCLER_ESCROW,
+    /// Reserved configuration.
+    Reserved = RESERVED,
+}
+
+impl ConfId {
+    /// Creates a new [ConfId].
+    pub const fn new() -> Self {
+        Self::Acceptor
+    }
+
+    /// Infallible conversion from a [`u8`] into a [ConfId].
+    pub const fn from_u8(val: u8) -> Self {
+        match val {
+            ACCEPTOR => Self::Acceptor,
+            ACCEPTOR_RECYCLER => Self::AcceptorRecycler,
+            ACCEPTOR_ESCROW => Self::AcceptorEscrow,
+            ACCEPTOR_RECYCLER_ESCROW => Self::AcceptorRecyclerEscrow,
+            _ => Self::Reserved,
+        }
+    }
+
+    /// Gets the length of the [ConfId].
+    pub const fn len() -> usize {
+        mem::size_of::<u8>()
+    }
+
+    /// Gets whether the [ConfId] contains a reserved variant.
+    pub const fn is_empty(&self) -> bool {
+        matches!(self, Self::Reserved)
+    }
+}
+
+impl Default for ConfId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<u8> for ConfId {
+    type Error = Error;
+
+    fn try_from(val: u8) -> Result<Self> {
+        match Self::from_u8(val) {
+            Self::Reserved => Err(Error::InvalidConfId(val)),
+            v => Ok(v),
+        }
+    }
+}
+
+impl From<&ConfId> for &'static str {
+    fn from(val: &ConfId) -> Self {
+        match val {
+            ConfId::Acceptor => "acceptor",
+            ConfId::AcceptorRecycler => "acceptor, recycler",
+            ConfId::AcceptorEscrow => "acceptor, escrow",
+            ConfId::AcceptorRecyclerEscrow => "acceptor, recyler, escrow",
+            ConfId::Reserved => "reserved",
+        }
+    }
+}
+
+impl From<ConfId> for &'static str {
+    fn from(val: ConfId) -> Self {
+        (&val).into()
+    }
+}
+
+impl fmt::Display for ConfId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, <&str>::from(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_id() {
+        let raw_denom = [
+            ACCEPTOR,
+            ACCEPTOR_RECYCLER,
+            ACCEPTOR_ESCROW,
+            ACCEPTOR_RECYCLER_ESCROW,
+        ];
+        let expected = [
+            ConfId::Acceptor,
+            ConfId::AcceptorRecycler,
+            ConfId::AcceptorEscrow,
+            ConfId::AcceptorRecyclerEscrow,
+        ];
+
+        for (raw, exp) in raw_denom.into_iter().zip(expected.into_iter()) {
+            assert_eq!(ConfId::try_from(raw), Ok(exp));
+            assert_eq!(ConfId::from_u8(raw), exp);
+        }
+
+        for stat in (0..=255u8).filter(|s| raw_denom.iter().find(|d| d == &s).is_none()) {
+            assert!(ConfId::try_from(stat).is_err());
+            assert_eq!(ConfId::from_u8(stat), ConfId::Reserved);
+        }
+    }
+}

--- a/src/message/func_id.rs
+++ b/src/message/func_id.rs
@@ -1,0 +1,120 @@
+use std::{fmt, mem};
+
+use crate::{Error, Result};
+
+const COMMON: u8 = 0b0000;
+const ACCEPTOR: u8 = 0b0001;
+const RECYCLER: u8 = 0b0010;
+const ESCROW: u8 = 0b0011;
+const RESERVED: u8 = 0xff;
+
+/// Represents the JCM device configuration ID.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FuncId {
+    /// Common (entire device).
+    Common = COMMON,
+    /// Acceptor function.
+    Acceptor = ACCEPTOR,
+    /// Recycler function.
+    Recycler = RECYCLER,
+    /// Escrow function.
+    Escrow = ESCROW,
+    /// Reserved function.
+    Reserved = RESERVED,
+}
+
+impl FuncId {
+    /// Creates a new [FuncId].
+    pub const fn new() -> Self {
+        Self::Common
+    }
+
+    /// Infallible conversion from a [`u8`] into a [FuncId].
+    pub const fn from_u8(val: u8) -> Self {
+        match val {
+            COMMON => Self::Common,
+            ACCEPTOR => Self::Acceptor,
+            RECYCLER => Self::Recycler,
+            ESCROW => Self::Escrow,
+            _ => Self::Reserved,
+        }
+    }
+
+    /// Gets the length of the [FuncId].
+    pub const fn len() -> usize {
+        mem::size_of::<u8>()
+    }
+
+    /// Gets whether the [FuncId] contains a reserved variant.
+    pub const fn is_empty(&self) -> bool {
+        matches!(self, Self::Reserved)
+    }
+}
+
+impl Default for FuncId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<u8> for FuncId {
+    type Error = Error;
+
+    fn try_from(val: u8) -> Result<Self> {
+        match Self::from_u8(val) {
+            Self::Reserved => Err(Error::InvalidFuncId(val)),
+            v => Ok(v),
+        }
+    }
+}
+
+impl From<&FuncId> for &'static str {
+    fn from(val: &FuncId) -> Self {
+        match val {
+            FuncId::Common => "common",
+            FuncId::Acceptor => "acceptor",
+            FuncId::Recycler => "recycler",
+            FuncId::Escrow => "escrow",
+            FuncId::Reserved => "reserved",
+        }
+    }
+}
+
+impl From<FuncId> for &'static str {
+    fn from(val: FuncId) -> Self {
+        (&val).into()
+    }
+}
+
+impl fmt::Display for FuncId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, <&str>::from(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_id() {
+        let raw_denom = [COMMON, ACCEPTOR, RECYCLER, ESCROW];
+        let expected = [
+            FuncId::Common,
+            FuncId::Acceptor,
+            FuncId::Recycler,
+            FuncId::Escrow,
+        ];
+
+        for (raw, exp) in raw_denom.into_iter().zip(expected.into_iter()) {
+            assert_eq!(FuncId::try_from(raw), Ok(exp));
+            assert_eq!(FuncId::from_u8(raw), exp);
+        }
+
+        for stat in (0..=255u8).filter(|s| raw_denom.iter().find(|d| d == &s).is_none()) {
+            assert!(FuncId::try_from(stat).is_err());
+            assert_eq!(FuncId::from_u8(stat), FuncId::Reserved);
+        }
+    }
+}

--- a/src/message/message_data.rs
+++ b/src/message/message_data.rs
@@ -1,0 +1,289 @@
+use std::{cmp, fmt, mem};
+
+use super::{ConfId, FuncId, MessageType, MAX_LEN};
+use crate::{Error, Result};
+
+/// Represents message data for JCM host-device communication.
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MessageData {
+    conf_id: ConfId,
+    uid: u8,
+    message_type: MessageType,
+    func_id: FuncId,
+    additional: Vec<u8>,
+}
+
+impl MessageData {
+    /// Creates a new [MessageData].
+    pub const fn new() -> Self {
+        Self {
+            conf_id: ConfId::new(),
+            uid: 0,
+            message_type: MessageType::new(),
+            func_id: FuncId::new(),
+            additional: Vec::new(),
+        }
+    }
+
+    /// Gets the [ConfId] of the [MessageData].
+    pub const fn conf_id(&self) -> ConfId {
+        self.conf_id
+    }
+
+    /// Sets the [ConfId] of the [MessageData].
+    pub fn set_conf_id(&mut self, val: ConfId) {
+        self.conf_id = val;
+    }
+
+    /// Builder function that sets the [ConfId] of the [MessageData].
+    pub fn with_conf_id(mut self, val: ConfId) -> Self {
+        self.set_conf_id(val);
+        self
+    }
+
+    /// Gets the UID of the [MessageData].
+    ///
+    /// - `0`: device powered on, and/or USB cable disconnected.
+    /// - `1-255`: device ID for disconnected device to send in a UID Request Message.
+    pub const fn uid(&self) -> u8 {
+        self.uid
+    }
+
+    /// Sets the UID of the [MessageData].
+    pub fn set_uid(&mut self, val: u8) {
+        self.uid = val;
+    }
+
+    /// Builder function that sets the UID of the [MessageData].
+    pub fn with_uid(mut self, val: u8) -> Self {
+        self.set_uid(val);
+        self
+    }
+
+    /// Gets the [MessageType] of the [MessageData].
+    pub const fn message_type(&self) -> MessageType {
+        self.message_type
+    }
+
+    /// Sets the [MessageType] of the [MessageData].
+    pub fn set_message_type(&mut self, val: MessageType) {
+        self.message_type = val;
+    }
+
+    /// Builder function that sets the [MessageType] of the [MessageData].
+    pub fn with_message_type(mut self, val: MessageType) -> Self {
+        self.set_message_type(val);
+        self
+    }
+
+    /// Gets the [FuncId] of the [MessageData].
+    pub const fn func_id(&self) -> FuncId {
+        self.func_id
+    }
+
+    /// Sets the [FuncId] of the [MessageData].
+    pub fn set_func_id(&mut self, val: FuncId) {
+        self.func_id = val;
+    }
+
+    /// Builder function that sets the [FuncId] of the [MessageData].
+    pub fn with_func_id(mut self, val: FuncId) -> Self {
+        self.set_func_id(val);
+        self
+    }
+
+    /// Gets a reference to the additional data of the [MessageData].
+    pub fn additional(&self) -> &[u8] {
+        &self.additional
+    }
+
+    /// Sets the additional data of the [MessageData].
+    pub fn set_additional(&mut self, additional: &[u8]) {
+        let len = cmp::min(additional.len(), MAX_LEN);
+        self.additional = additional[..len].into()
+    }
+
+    /// Builder function that sets the additional data of the [MessageData].
+    pub fn with_additional(mut self, additional: &[u8]) -> Self {
+        self.set_additional(additional);
+        self
+    }
+
+    /// Gets the length of the [MessageData].
+    pub fn len(&self) -> usize {
+        Self::meta_len() + self.additional.len()
+    }
+
+    pub(crate) const fn meta_len() -> usize {
+        ConfId::len() + mem::size_of::<u8>() + MessageType::len() + FuncId::len()
+    }
+
+    /// Gets whether the [MessageData] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.additional.is_empty()
+    }
+}
+
+impl From<&MessageData> for Vec<u8> {
+    fn from(val: &MessageData) -> Self {
+        [
+            val.conf_id as u8,
+            val.uid,
+            val.message_type.into(),
+            val.func_id as u8,
+        ]
+        .into_iter()
+        .chain(val.additional.iter().cloned())
+        .collect()
+    }
+}
+
+impl From<MessageData> for Vec<u8> {
+    fn from(val: MessageData) -> Self {
+        [
+            val.conf_id as u8,
+            val.uid,
+            val.message_type.into(),
+            val.func_id as u8,
+        ]
+        .into_iter()
+        .chain(val.additional)
+        .collect()
+    }
+}
+
+impl TryFrom<&[u8]> for MessageData {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        let len = val.len();
+        let meta_len = Self::meta_len();
+
+        if len < meta_len {
+            Err(Error::InvalidMessageDataLen((len, meta_len)))
+        } else if len > MAX_LEN {
+            Err(Error::InvalidMessageDataLen((len, MAX_LEN)))
+        } else {
+            let conf_id = ConfId::try_from(val[0])?;
+            let uid = val[1];
+            let message_type = MessageType::try_from(val[2])?;
+            let func_id = FuncId::try_from(val[3])?;
+            let additional = val[4..].into();
+
+            Ok(Self {
+                conf_id,
+                uid,
+                message_type,
+                func_id,
+                additional,
+            })
+        }
+    }
+}
+
+impl fmt::Display for MessageData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""conf_id": {},"#, self.conf_id)?;
+        write!(f, r#""uid": {},"#, self.uid)?;
+        write!(f, r#""message_type": {},"#, self.message_type)?;
+        write!(f, r#""func_id": {},"#, self.func_id)?;
+        write!(f, r#""additional": ["#)?;
+        for (i, d) in self.additional.iter().enumerate() {
+            if i != 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{d}")?;
+        }
+        write!(f, "]}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_message_data() -> Result<()> {
+        let raw: [u8; 4] = [
+            // conf ID
+            0x10,
+            // UID
+            0x00,
+            // message type
+            0x00,
+            // func ID
+            0x00,
+            // additional data (none)
+        ];
+
+        let exp = MessageData::new();
+        let msg = MessageData::try_from(raw.as_ref())?;
+
+        assert_eq!(msg, exp);
+
+        Ok(())
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_message_data_with_additional() -> Result<()> {
+        let raw: [u8; 12] = [
+            // conf ID
+            0x10,
+            // UID
+            0x00,
+            // message type
+            0x00,
+            // func ID
+            0x00,
+            // additional data
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        ];
+
+        let exp = MessageData::new().with_additional(&raw[4..]);
+        let msg = MessageData::try_from(raw.as_ref())?;
+
+        assert_eq!(msg, exp);
+
+        Ok(())
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_message_data_too_short() -> Result<()> {
+        let raw: [u8; 3] = [
+            // conf ID
+            0x10,
+            // UID
+            0x00,
+            // message type
+            0x00,
+        ];
+
+        assert!(MessageData::try_from(raw.as_ref()).is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_message_data_too_long() -> Result<()> {
+        let raw: Vec<u8> = [
+            // conf ID
+            0x10,
+            // UID
+            0x00,
+            // message type
+            0x00,
+            // func ID
+            0x00,
+        ].into_iter().chain([0xff; MAX_LEN].into_iter()).collect();
+
+        assert!(MessageData::try_from(raw.as_ref()).is_err());
+
+        Ok(())
+    }
+}

--- a/src/message/message_id.rs
+++ b/src/message/message_id.rs
@@ -1,0 +1,98 @@
+use std::{fmt, mem};
+
+use crate::{Error, Result};
+
+const MESSAGE: u8 = 0x12;
+const RESERVED: u8 = 0xff;
+
+/// Represents the `ID` field of a message.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MessageId {
+    Message = MESSAGE,
+    Reserved = RESERVED,
+}
+
+impl MessageId {
+    /// Creates a new [MessageId].
+    pub const fn new() -> Self {
+        Self::Message
+    }
+
+    /// Infallible conversion from a [`u8`] into a [MessageId].
+    pub const fn from_u8(val: u8) -> Self {
+        match val {
+            MESSAGE => Self::Message,
+            _ => Self::Reserved,
+        }
+    }
+
+    /// Gets the length of the [MessageId].
+    pub const fn len() -> usize {
+        mem::size_of::<u8>()
+    }
+
+    /// Gets whether the [MessageId] contains a reserved variant.
+    pub const fn is_empty(&self) -> bool {
+        matches!(self, Self::Reserved)
+    }
+}
+
+impl Default for MessageId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<u8> for MessageId {
+    type Error = Error;
+
+    fn try_from(val: u8) -> Result<Self> {
+        match Self::from_u8(val) {
+            Self::Reserved => Err(Error::InvalidMessageId(val)),
+            v => Ok(v),
+        }
+    }
+}
+
+impl From<&MessageId> for &'static str {
+    fn from(val: &MessageId) -> Self {
+        match val {
+            MessageId::Message => "message",
+            MessageId::Reserved => "reserved",
+        }
+    }
+}
+
+impl From<MessageId> for &'static str {
+    fn from(val: MessageId) -> Self {
+        (&val).into()
+    }
+}
+
+impl fmt::Display for MessageId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, <&str>::from(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_id() {
+        let raw_denom = [MESSAGE];
+        let expected = [MessageId::Message];
+
+        for (raw, exp) in raw_denom.into_iter().zip(expected.into_iter()) {
+            assert_eq!(MessageId::try_from(raw), Ok(exp));
+            assert_eq!(MessageId::from_u8(raw), exp);
+        }
+
+        for stat in (0..=255u8).filter(|s| raw_denom.iter().find(|d| d == &s).is_none()) {
+            assert!(MessageId::try_from(stat).is_err());
+            assert_eq!(MessageId::from_u8(stat), MessageId::Reserved);
+        }
+    }
+}

--- a/src/message/message_type.rs
+++ b/src/message/message_type.rs
@@ -1,0 +1,90 @@
+use std::{fmt, mem};
+
+use crate::{Error, Result};
+
+mod event_type;
+mod request_type;
+
+pub use event_type::*;
+pub use request_type::*;
+
+const RESERVED: u8 = 0xff;
+
+/// Represents the message type.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MessageType {
+    /// Host-to-device request message.
+    Request(RequestType),
+    /// Device-to-host status event.
+    Event(EventType),
+    /// Reserved message type.
+    Reserved = RESERVED,
+}
+
+impl MessageType {
+    /// Creates a new [MessageType].
+    pub const fn new() -> Self {
+        Self::Request(RequestType::new())
+    }
+
+    /// Infallible conversion from a [`u8`] into a [RequestType].
+    pub const fn from_u8(val: u8) -> Self {
+        match (RequestType::from_u8(val), EventType::from_u8(val)) {
+            (RequestType::Reserved, EventType::Reserved) => Self::Reserved,
+            (req, EventType::Reserved) => Self::Request(req),
+            (RequestType::Reserved, event) => Self::Event(event),
+            // NOTE: technically `unreachable`, but let's make the compiler happy without `panic`ing
+            (_, _) => Self::Reserved,
+        }
+    }
+
+    /// Gets the length of the [MessageType].
+    pub const fn len() -> usize {
+        mem::size_of::<u8>()
+    }
+
+    /// Gets whether the [MessageType] contains a reserved variant.
+    pub const fn is_empty(&self) -> bool {
+        matches!(self, Self::Reserved)
+            || matches!(self, Self::Request(RequestType::Reserved))
+            || matches!(self, Self::Event(EventType::Reserved))
+    }
+}
+
+impl TryFrom<u8> for MessageType {
+    type Error = Error;
+
+    fn try_from(val: u8) -> Result<Self> {
+        match Self::from_u8(val) {
+            Self::Reserved => Err(Error::InvalidMessageType(val)),
+            v => Ok(v),
+        }
+    }
+}
+
+impl From<MessageType> for u8 {
+    fn from(val: MessageType) -> Self {
+        match val {
+            MessageType::Request(ty) => ty as u8,
+            MessageType::Event(ty) => ty as u8,
+            _ => RESERVED,
+        }
+    }
+}
+
+impl From<&MessageType> for u8 {
+    fn from(val: &MessageType) -> Self {
+        (*val).into()
+    }
+}
+
+impl fmt::Display for MessageType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Request(mt) => write!(f, r#"{{"message_type": "request", "code": {mt}}}"#),
+            Self::Event(mt) => write!(f, r#"{{"message_type": "event", "code": {mt}}}"#),
+            Self::Reserved => write!(f, r#"{{"message_type": "reserved", "code": "reserved"}}"#),
+        }
+    }
+}

--- a/src/message/message_type/event_type.rs
+++ b/src/message/message_type/event_type.rs
@@ -1,0 +1,176 @@
+use std::fmt;
+
+use super::*;
+use crate::{Error, Result};
+
+const EVENT_SEQUENCE0: u8 = 0x80;
+const EVENT_SEQUENCE1: u8 = 0x81;
+const EVENT_SEQUENCE2: u8 = 0x82;
+const EVENT_SEQUENCE3: u8 = 0x83;
+const EVENT_SEQUENCE4: u8 = 0x84;
+const EVENT_SEQUENCE5: u8 = 0x85;
+const EVENT_SEQUENCE6: u8 = 0x86;
+const EVENT_SEQUENCE7: u8 = 0x87;
+const EVENT_SEQUENCE8: u8 = 0x88;
+const EVENT_SEQUENCE9: u8 = 0x89;
+const EVENT_SEQUENCE10: u8 = 0x8a;
+const EVENT_SEQUENCE11: u8 = 0x8b;
+const EVENT_SEQUENCE12: u8 = 0x8c;
+const EVENT_SEQUENCE13: u8 = 0x8d;
+const EVENT_SEQUENCE14: u8 = 0x8e;
+const EVENT_SEQUENCE15: u8 = 0x8f;
+
+/// Represents the sequence number of the device-to-host event status message.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EventType {
+    Sequence0 = EVENT_SEQUENCE0,
+    Sequence1 = EVENT_SEQUENCE1,
+    Sequence2 = EVENT_SEQUENCE2,
+    Sequence3 = EVENT_SEQUENCE3,
+    Sequence4 = EVENT_SEQUENCE4,
+    Sequence5 = EVENT_SEQUENCE5,
+    Sequence6 = EVENT_SEQUENCE6,
+    Sequence7 = EVENT_SEQUENCE7,
+    Sequence8 = EVENT_SEQUENCE8,
+    Sequence9 = EVENT_SEQUENCE9,
+    Sequence10 = EVENT_SEQUENCE10,
+    Sequence11 = EVENT_SEQUENCE11,
+    Sequence12 = EVENT_SEQUENCE12,
+    Sequence13 = EVENT_SEQUENCE13,
+    Sequence14 = EVENT_SEQUENCE14,
+    Sequence15 = EVENT_SEQUENCE15,
+    Reserved = RESERVED,
+}
+
+impl EventType {
+    /// Creates a new [EventType].
+    pub const fn new() -> Self {
+        Self::Sequence0
+    }
+
+    /// Infallible conversion from a [`u8`] into a [EventType].
+    pub const fn from_u8(val: u8) -> Self {
+        match val {
+            EVENT_SEQUENCE0 => Self::Sequence0,
+            EVENT_SEQUENCE1 => Self::Sequence1,
+            EVENT_SEQUENCE2 => Self::Sequence2,
+            EVENT_SEQUENCE3 => Self::Sequence3,
+            EVENT_SEQUENCE4 => Self::Sequence4,
+            EVENT_SEQUENCE5 => Self::Sequence5,
+            EVENT_SEQUENCE6 => Self::Sequence6,
+            EVENT_SEQUENCE7 => Self::Sequence7,
+            EVENT_SEQUENCE8 => Self::Sequence8,
+            EVENT_SEQUENCE9 => Self::Sequence9,
+            EVENT_SEQUENCE10 => Self::Sequence10,
+            EVENT_SEQUENCE11 => Self::Sequence11,
+            EVENT_SEQUENCE12 => Self::Sequence12,
+            EVENT_SEQUENCE13 => Self::Sequence13,
+            EVENT_SEQUENCE14 => Self::Sequence14,
+            EVENT_SEQUENCE15 => Self::Sequence15,
+            _ => Self::Reserved,
+        }
+    }
+}
+
+impl TryFrom<u8> for EventType {
+    type Error = Error;
+
+    fn try_from(val: u8) -> Result<Self> {
+        match Self::from_u8(val) {
+            Self::Reserved => Err(Error::InvalidMessageType(val)),
+            v => Ok(v),
+        }
+    }
+}
+
+impl From<&EventType> for &'static str {
+    fn from(val: &EventType) -> Self {
+        match val {
+            EventType::Sequence0 => "event sequence 0",
+            EventType::Sequence1 => "event sequence 1",
+            EventType::Sequence2 => "event sequence 2",
+            EventType::Sequence3 => "event sequence 3",
+            EventType::Sequence4 => "event sequence 4",
+            EventType::Sequence5 => "event sequence 5",
+            EventType::Sequence6 => "event sequence 6",
+            EventType::Sequence7 => "event sequence 7",
+            EventType::Sequence8 => "event sequence 8",
+            EventType::Sequence9 => "event sequence 9",
+            EventType::Sequence10 => "event sequence 10",
+            EventType::Sequence11 => "event sequence 11",
+            EventType::Sequence12 => "event sequence 12",
+            EventType::Sequence13 => "event sequence 13",
+            EventType::Sequence14 => "event sequence 14",
+            EventType::Sequence15 => "event sequence 15",
+            EventType::Reserved => "reserved",
+        }
+    }
+}
+
+impl From<EventType> for &'static str {
+    fn from(val: EventType) -> Self {
+        (&val).into()
+    }
+}
+
+impl fmt::Display for EventType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, <&str>::from(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_event_type() {
+        let raw_denom = [
+            EVENT_SEQUENCE0,
+            EVENT_SEQUENCE1,
+            EVENT_SEQUENCE2,
+            EVENT_SEQUENCE3,
+            EVENT_SEQUENCE4,
+            EVENT_SEQUENCE5,
+            EVENT_SEQUENCE6,
+            EVENT_SEQUENCE7,
+            EVENT_SEQUENCE8,
+            EVENT_SEQUENCE9,
+            EVENT_SEQUENCE10,
+            EVENT_SEQUENCE11,
+            EVENT_SEQUENCE12,
+            EVENT_SEQUENCE13,
+            EVENT_SEQUENCE14,
+            EVENT_SEQUENCE15,
+        ];
+        let expected = [
+            EventType::Sequence0,
+            EventType::Sequence1,
+            EventType::Sequence2,
+            EventType::Sequence3,
+            EventType::Sequence4,
+            EventType::Sequence5,
+            EventType::Sequence6,
+            EventType::Sequence7,
+            EventType::Sequence8,
+            EventType::Sequence9,
+            EventType::Sequence10,
+            EventType::Sequence11,
+            EventType::Sequence12,
+            EventType::Sequence13,
+            EventType::Sequence14,
+            EventType::Sequence15,
+        ];
+
+        for (raw, exp) in raw_denom.into_iter().zip(expected.into_iter()) {
+            assert_eq!(EventType::try_from(raw), Ok(exp));
+            assert_eq!(EventType::from_u8(raw), exp);
+        }
+
+        for stat in (0..=255u8).filter(|s| raw_denom.iter().find(|d| d == &s).is_none()) {
+            assert!(EventType::try_from(stat).is_err());
+            assert_eq!(EventType::from_u8(stat), EventType::Reserved);
+        }
+    }
+}

--- a/src/message/message_type/request_type.rs
+++ b/src/message/message_type/request_type.rs
@@ -1,0 +1,94 @@
+use std::fmt;
+
+use super::*;
+use crate::{Error, Result};
+
+const OPERATION_REQ: u8 = 0b0000_0000;
+const STATUS_REQ: u8 = 0b0001_0000;
+const SET_FEATURE_REQ: u8 = 0b0010_0000;
+
+/// Represents the type of host-to-device request message.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RequestType {
+    Operation = OPERATION_REQ,
+    Status = STATUS_REQ,
+    SetFeature = SET_FEATURE_REQ,
+    Reserved = RESERVED,
+}
+
+impl RequestType {
+    /// Creates a new [RequestType].
+    pub const fn new() -> Self {
+        Self::Operation
+    }
+
+    /// Infallible conversion from a [`u8`] into a [RequestType].
+    pub const fn from_u8(val: u8) -> Self {
+        match val {
+            OPERATION_REQ => Self::Operation,
+            STATUS_REQ => Self::Status,
+            SET_FEATURE_REQ => Self::SetFeature,
+            _ => Self::Reserved,
+        }
+    }
+}
+
+impl TryFrom<u8> for RequestType {
+    type Error = Error;
+
+    fn try_from(val: u8) -> Result<Self> {
+        match Self::from_u8(val) {
+            Self::Reserved => Err(Error::InvalidMessageType(val)),
+            v => Ok(v),
+        }
+    }
+}
+
+impl From<&RequestType> for &'static str {
+    fn from(val: &RequestType) -> Self {
+        match val {
+            RequestType::Operation => "operation",
+            RequestType::Status => "status",
+            RequestType::SetFeature => "set feature",
+            RequestType::Reserved => "reserved",
+        }
+    }
+}
+
+impl From<RequestType> for &'static str {
+    fn from(val: RequestType) -> Self {
+        (&val).into()
+    }
+}
+
+impl fmt::Display for RequestType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, <&str>::from(self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_type() {
+        let raw_denom = [OPERATION_REQ, STATUS_REQ, SET_FEATURE_REQ];
+        let expected = [
+            RequestType::Operation,
+            RequestType::Status,
+            RequestType::SetFeature,
+        ];
+
+        for (raw, exp) in raw_denom.into_iter().zip(expected.into_iter()) {
+            assert_eq!(RequestType::try_from(raw), Ok(exp));
+            assert_eq!(RequestType::from_u8(raw), exp);
+        }
+
+        for stat in (0..=255u8).filter(|s| raw_denom.iter().find(|d| d == &s).is_none()) {
+            assert!(RequestType::try_from(stat).is_err());
+            assert_eq!(RequestType::from_u8(stat), RequestType::Reserved);
+        }
+    }
+}


### PR DESCRIPTION
Adds the `Message` and related data types for generic JCM host-device communication.