### PR TITLE
fixup: lint, formatting, and encoding fixes

### DIFF
--- a/src/message/response/status_response.rs
+++ b/src/message/response/status_response.rs
@@ -192,8 +192,8 @@ impl From<&StatusResponse> for Response {
             code: val.code,
             additional: [val.len() as u8]
                 .into_iter()
-                .chain(val.status.to_bytes().into_iter())
-                .chain(val.unit_status.to_bytes().into_iter())
+                .chain(val.status.to_bytes())
+                .chain(val.unit_status.to_bytes())
                 .collect(),
         }
     }

--- a/src/unit_status.rs
+++ b/src/unit_status.rs
@@ -156,8 +156,24 @@ impl UnitStatusList {
         self.0
     }
 
+    /// Writes the [UnitStatusList] to a byte buffer.
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<()> {
+        let len = self.len();
+        let buf_len = buf.len();
+
+        if buf_len < len {
+            Err(Error::InvalidUnitStatusListLen((buf_len, len)))
+        } else {
+            buf.iter_mut()
+                .zip(self.0.iter().flat_map(|c| c.to_bytes()))
+                .for_each(|(dst, src)| *dst = src);
+
+            Ok(())
+        }
+    }
+
     /// Converts the [UnitStatusList] into a byte vector.
-    pub fn to_bytes(&self) -> Vec<u8> {
+    pub fn as_bytes(&self) -> Vec<u8> {
         self.0.iter().flat_map(|c| c.to_bytes()).collect()
     }
 

--- a/src/unit_status.rs
+++ b/src/unit_status.rs
@@ -158,16 +158,12 @@ impl UnitStatusList {
 
     /// Converts the [UnitStatusList] into a byte vector.
     pub fn to_bytes(&self) -> Vec<u8> {
-        self.0.iter().map(|c| c.to_bytes()).flatten().collect()
+        self.0.iter().flat_map(|c| c.to_bytes()).collect()
     }
 
     /// Converts the [UnitStatusList] into a byte vector.
     pub fn into_bytes(self) -> Vec<u8> {
-        self.0
-            .into_iter()
-            .map(|c| c.into_bytes())
-            .flatten()
-            .collect()
+        self.0.into_iter().flat_map(|c| c.into_bytes()).collect()
     }
 
     /// Gets the byte length of the [UnitStatusList].


### PR DESCRIPTION
`clippy` and formatting fixes.

Changes the `UnitStatus::to_bytes` to write to a byte buffer to avoid an unnecessary heap allocation.

Adds the `UnitStatus::as_bytes` implementation with the previous `to_bytes` semantics.