### PR TITLE
maintenance: add detail messages for message codes

### DIFF
--- a/src/message/message_code.rs
+++ b/src/message/message_code.rs
@@ -142,13 +142,13 @@ impl fmt::Display for MessageCode {
         match self {
             Self::Request(c) => write!(
                 f,
-                r#"{{"message_type": "request", "code": {:#x}, "details": {c}}}"#,
-                u16::from(c)
+                r#"{{"message_type": "request", "code": {c}, "details": {}}}"#,
+                RequestCodeDetails(*c)
             ),
             Self::Event(c) => write!(
                 f,
-                r#"{{"message_type": "event", "code": {:#x}, "details": {c}}}"#,
-                u16::from(c)
+                r#"{{"message_type": "event", "code": {c}, "details": {}}}"#,
+                EventCodeDetails(*c)
             ),
             Self::Reserved => write!(
                 f,

--- a/src/message/message_code/event_code.rs
+++ b/src/message/message_code/event_code.rs
@@ -191,9 +191,62 @@ impl TryFrom<u16> for EventCode {
     }
 }
 
+impl From<EventCode> for &'static str {
+    fn from(val: EventCode) -> Self {
+        match val {
+            EventCode::PowerUp => "PowerUp",
+            EventCode::PowerUpAcceptor => "PowerUpAcceptor",
+            EventCode::PowerUpStacker => "PowerUpStacker",
+            EventCode::Inhibit => "Inhibit",
+            EventCode::ProgramSignature => "ProgramSignature",
+            EventCode::Rejected => "Rejected",
+            EventCode::Collected => "Collected",
+            EventCode::Clear => "Clear",
+            EventCode::OperationError => "OperationError",
+            EventCode::Failure => "Failure",
+            EventCode::NoteStay => "NoteStay",
+            EventCode::PowerUpAcceptorAccepting => "PowerUpAcceptorAccepting",
+            EventCode::PowerUpStackerAccepting => "PowerUpStackerAccepting",
+            EventCode::Idle => "Idle",
+            EventCode::Escrow => "Escrow",
+            EventCode::VendValid => "VendValid",
+            EventCode::AcceptorRejected => "AcceptorRejected",
+            EventCode::Returned => "Returned",
+            EventCode::AcceptorCollected => "AcceptorCollected",
+            EventCode::Insert => "Insert",
+            EventCode::ConditionalVend => "ConditionalVend",
+            EventCode::Pause => "Pause",
+            EventCode::Resume => "Resume",
+            EventCode::AcceptorClear => "AcceptorClear",
+            EventCode::AcceptorOperationError => "AcceptorOperationError",
+            EventCode::AcceptorFailure => "AcceptorFailure",
+            EventCode::AcceptorNoteStay => "AcceptorNoteStay",
+            EventCode::FunctionAbeyance => "FunctionAbeyance",
+            EventCode::Reserved => "Reserved",
+        }
+    }
+}
+
 impl From<&EventCode> for &'static str {
     fn from(val: &EventCode) -> Self {
-        match val {
+        (*val).into()
+    }
+}
+
+impl fmt::Display for EventCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, <&str>::from(self))
+    }
+}
+
+/// Convenience struct to display details for [EventCode].
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EventCodeDetails(pub EventCode);
+
+impl From<EventCodeDetails> for &'static str {
+    fn from(val: EventCodeDetails) -> Self {
+        match val.0 {
             EventCode::PowerUp => "normal `Power Up` status",
             EventCode::PowerUpAcceptor => "detected a returnable note on `Power Up`",
             EventCode::PowerUpStacker => "detected a non-returnable note on `Power Up`",
@@ -235,13 +288,13 @@ impl From<&EventCode> for &'static str {
     }
 }
 
-impl From<EventCode> for &'static str {
-    fn from(val: EventCode) -> Self {
-        (&val).into()
+impl From<&EventCodeDetails> for &'static str {
+    fn from(val: &EventCodeDetails) -> Self {
+        (*val).into()
     }
 }
 
-impl fmt::Display for EventCode {
+impl fmt::Display for EventCodeDetails {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, r#""{}""#, <&str>::from(self))
     }

--- a/src/message/message_code/request_code.rs
+++ b/src/message/message_code/request_code.rs
@@ -189,9 +189,61 @@ impl TryFrom<u16> for RequestCode {
     }
 }
 
+impl From<RequestCode> for &'static str {
+    fn from(val: RequestCode) -> Self {
+        match val {
+            RequestCode::Uid => "Uid",
+            RequestCode::ProgramSignature => "ProgramSignature",
+            RequestCode::Version => "Version",
+            RequestCode::SerialNumber => "SerialNumber",
+            RequestCode::ModelName => "ModelName",
+            RequestCode::Status => "Status",
+            RequestCode::Reset => "Reset",
+            RequestCode::Inhibit => "Inhibit",
+            RequestCode::Collect => "Collect",
+            RequestCode::Key => "Key",
+            RequestCode::EventResendInterval => "EventResendInterval",
+            RequestCode::Idle => "Idle",
+            RequestCode::Stack => "Stack",
+            RequestCode::Reject => "Reject",
+            RequestCode::Hold => "Hold",
+            RequestCode::AcceptorCollect => "AcceptorCollect",
+            RequestCode::DenominationDisable => "DenominationDisable",
+            RequestCode::DirectionDisable => "DirectionDisable",
+            RequestCode::CurrencyAssign => "CurrencyAssign",
+            RequestCode::CashBoxSize => "CashBoxSize",
+            RequestCode::NearFull => "NearFull",
+            RequestCode::BarCode => "BarCode",
+            RequestCode::Insert => "Insert",
+            RequestCode::ConditionalVend => "ConditionalVend",
+            RequestCode::Pause => "Pause",
+            RequestCode::NoteDataInfo => "NoteDataInfo",
+            RequestCode::RecyclerCollect => "RecyclerCollect",
+            RequestCode::Reserved => "Reserved",
+        }
+    }
+}
+
 impl From<&RequestCode> for &'static str {
     fn from(val: &RequestCode) -> Self {
-        match val {
+        (*val).into()
+    }
+}
+
+impl fmt::Display for RequestCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, <&str>::from(self))
+    }
+}
+
+/// Convenience struct to display details for [RequestCode].
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RequestCodeDetails(pub RequestCode);
+
+impl From<RequestCodeDetails> for &'static str {
+    fn from(val: RequestCodeDetails) -> Self {
+        match val.0 {
             RequestCode::Uid => "request to get/set UID information",
             RequestCode::ProgramSignature => "request hash value of the firmware, or the supported hash algorithm",
             RequestCode::Version => "request the version of the device firmware",
@@ -219,18 +271,18 @@ impl From<&RequestCode> for &'static str {
             RequestCode::Pause => "request to send or set the `Pause` duration, and `Status and Event Message` enabled/disabled settings information",
             RequestCode::NoteDataInfo => "request to send information of an inserted note",
             RequestCode::RecyclerCollect => "request for retrieving",
-            RequestCode::Reserved => "reserved",
+            RequestCode::Reserved => "reserved code",
         }
     }
 }
 
-impl From<RequestCode> for &'static str {
-    fn from(val: RequestCode) -> Self {
-        (&val).into()
+impl From<&RequestCodeDetails> for &'static str {
+    fn from(val: &RequestCodeDetails) -> Self {
+        (*val).into()
     }
 }
 
-impl fmt::Display for RequestCode {
+impl fmt::Display for RequestCodeDetails {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, r#""{}""#, <&str>::from(self))
     }


### PR DESCRIPTION
Adds convenience types for displaying detailed messages for `EventCode` and `RequestCode` types.