### PR TITLE
message: fix message conversion to bytes

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -102,7 +102,7 @@ impl From<&Message> for Vec<u8> {
     fn from(val: &Message) -> Self {
         [val.id.into()]
             .into_iter()
-            .chain((val.data.len() as u16).to_be_bytes())
+            .chain((val.len() as u16).to_le_bytes())
             .chain(Vec::<u8>::from(val.data()))
             .collect()
     }
@@ -112,7 +112,7 @@ impl From<Message> for Vec<u8> {
     fn from(val: Message) -> Self {
         [val.id.into()]
             .into_iter()
-            .chain((val.data.len() as u16).to_be_bytes())
+            .chain((val.len() as u16).to_le_bytes())
             .chain(Vec::<u8>::from(val.data))
             .collect()
     }


### PR DESCRIPTION
Fixes the message length field byte order, and value of message length.

The `Message` length field needs to cover the entire message length, and be encoded in little-endian order.