### PR TITLE
version: bump to `v0.1.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "jcm"
-version = "0.1.0-pre-release"
+version = "0.1.0"
 dependencies = [
  "crossbeam",
  "currency-iso4217",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jcm"
-version = "0.1.0-pre-release"
+version = "0.1.0"
 edition = "2021"
 authors = ["JCM Rust Developers"]
 description = "Pure Rust implementation of the JCM USB communication protocol"


### PR DESCRIPTION
Bumps to the first release version.

Includes:

- all basic message structures for communication over the `ID-008` USB protocol
- basic functions for USB communication