### PR TITLE
message: add `Request` type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -31,8 +31,11 @@ pub enum Error {
     InvalidUnitStatusListLen((usize, usize)),
     InvalidStackRequestDataLen((usize, usize)),
     InvalidEventLen((usize, usize)),
+    InvalidRequestLen((usize, usize)),
     InvalidStackStatusChange(u8),
     InvalidRejectCode(u8),
+    InvalidRequestType(u8),
+    InvalidEventType(u8),
     #[cfg(feature = "usb")]
     Usb(String),
 }
@@ -108,11 +111,20 @@ impl fmt::Display for Error {
             Self::InvalidEventLen((have, exp)) => {
                 write!(f, "invalid event length, have: {have}, expected: {exp}")
             }
+            Self::InvalidRequestLen((have, exp)) => {
+                write!(f, "invalid request length, have: {have}, expected: {exp}")
+            }
             Self::InvalidStackStatusChange(err) => {
                 write!(f, "invalid stack status change: {err:#x}")
             }
             Self::InvalidRejectCode(err) => {
                 write!(f, "invalid reject code: {err:#x}")
+            }
+            Self::InvalidRequestType(err) => {
+                write!(f, "invalid request type: {err:#x}")
+            }
+            Self::InvalidEventType(err) => {
+                write!(f, "invalid event type: {err:#x}")
             }
             #[cfg(feature = "usb")]
             Self::Usb(err) => write!(f, "USB error: {err}"),

--- a/src/message/message_data/message_code/event_code.rs
+++ b/src/message/message_data/message_code/event_code.rs
@@ -141,6 +141,11 @@ impl EventCode {
         }
     }
 
+    /// Converts the [EventCode] into a byte array.
+    pub const fn to_bytes(&self) -> [u8; 2] {
+        (*self as u16).to_le_bytes()
+    }
+
     /// Gets the length of the [EventCode].
     pub const fn len() -> usize {
         mem::size_of::<u16>()
@@ -159,11 +164,6 @@ impl EventCode {
     /// Gets whether the [EventCode] is a valid variant.
     pub const fn is_valid(&self) -> bool {
         !self.is_empty()
-    }
-
-    /// Converts the [EventCode] into a byte array.
-    pub fn to_bytes(&self) -> [u8; 2] {
-        (*self as u16).to_le_bytes()
     }
 }
 
@@ -193,6 +193,34 @@ impl TryFrom<u16> for EventCode {
             Self::Reserved => Err(Error::InvalidEventCode(val)),
             v => Ok(v),
         }
+    }
+}
+
+impl TryFrom<&[u8]> for EventCode {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        match val.len() {
+            0 => Err(Error::InvalidEventCode(0)),
+            1 => Err(Error::InvalidEventCode(val[0] as u16)),
+            _ => u16::from_le_bytes([val[0], val[1]]).try_into(),
+        }
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for EventCode {
+    type Error = Error;
+
+    fn try_from(val: &[u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+
+impl<const N: usize> TryFrom<[u8; N]> for EventCode {
+    type Error = Error;
+
+    fn try_from(val: [u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
     }
 }
 
@@ -235,34 +263,6 @@ impl From<EventCode> for &'static str {
 impl From<&EventCode> for &'static str {
     fn from(val: &EventCode) -> Self {
         (*val).into()
-    }
-}
-
-impl TryFrom<&[u8]> for EventCode {
-    type Error = Error;
-
-    fn try_from(val: &[u8]) -> Result<Self> {
-        match val.len() {
-            0 => Err(Error::InvalidEventCode(0)),
-            1 => Err(Error::InvalidEventCode(val[0] as u16)),
-            _ => Self::try_from(u16::from_le_bytes([val[0], val[1]])),
-        }
-    }
-}
-
-impl<const N: usize> TryFrom<&[u8; N]> for EventCode {
-    type Error = Error;
-
-    fn try_from(val: &[u8; N]) -> Result<Self> {
-        val.as_ref().try_into()
-    }
-}
-
-impl<const N: usize> TryFrom<[u8; N]> for EventCode {
-    type Error = Error;
-
-    fn try_from(val: [u8; N]) -> Result<Self> {
-        val.as_ref().try_into()
     }
 }
 

--- a/src/message/message_data/message_code/request_code.rs
+++ b/src/message/message_data/message_code/request_code.rs
@@ -139,6 +139,11 @@ impl RequestCode {
         }
     }
 
+    /// Converts the [RequestCode] to a byte array.
+    pub const fn to_bytes(&self) -> [u8; 2] {
+        (*self as u16).to_le_bytes()
+    }
+
     /// Extracts the [FuncId] from the [RequestCode].
     pub const fn func_id(&self) -> FuncId {
         FuncId::from_u16(*self as u16)
@@ -186,6 +191,34 @@ impl TryFrom<u16> for RequestCode {
             Self::Reserved => Err(Error::InvalidRequestCode(val)),
             v => Ok(v),
         }
+    }
+}
+
+impl TryFrom<&[u8]> for RequestCode {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        match val.len() {
+            0 => Err(Error::InvalidRequestCode(0)),
+            1 => Err(Error::InvalidRequestCode(val[0] as u16)),
+            _ => u16::from_le_bytes([val[0], val[1]]).try_into(),
+        }
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for RequestCode {
+    type Error = Error;
+
+    fn try_from(val: &[u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+
+impl<const N: usize> TryFrom<[u8; N]> for RequestCode {
+    type Error = Error;
+
+    fn try_from(val: [u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
     }
 }
 

--- a/src/message/message_data/message_type.rs
+++ b/src/message/message_data/message_type.rs
@@ -39,9 +39,34 @@ impl MessageType {
         }
     }
 
+    /// Converts the [MessageType] to a [`u8`].
+    pub const fn to_u8(&self) -> u8 {
+        match self {
+            Self::Request(c) => c.to_u8(),
+            Self::Event(c) => c.to_u8(),
+            Self::Reserved => RESERVED,
+        }
+    }
+
     /// Gets the length of the [MessageType].
     pub const fn len() -> usize {
         mem::size_of::<u8>()
+    }
+
+    /// Attempts to get the [MessageType] as a [RequestType].
+    pub const fn request_type(&self) -> Result<RequestType> {
+        match self {
+            Self::Request(req) => Ok(*req),
+            _ => Err(Error::InvalidRequestType(self.to_u8())),
+        }
+    }
+
+    /// Attempts to get the [MessageType] as a [EventType].
+    pub const fn event_type(&self) -> Result<EventType> {
+        match self {
+            Self::Event(evt) => Ok(*evt),
+            _ => Err(Error::InvalidEventType(self.to_u8())),
+        }
     }
 
     pub const fn is_request(&self) -> bool {

--- a/src/message/message_data/message_type/event_type.rs
+++ b/src/message/message_data/message_type/event_type.rs
@@ -71,6 +71,26 @@ impl EventType {
             _ => Self::Reserved,
         }
     }
+
+    /// Converts the [EventType] to a [`u8`].
+    pub const fn to_u8(&self) -> u8 {
+        *self as u8
+    }
+
+    /// Gets the length of the [EventType].
+    pub const fn len() -> usize {
+        mem::size_of::<u8>()
+    }
+
+    /// Gets whether the [EventType] contains a reserved variant.
+    pub const fn is_empty(&self) -> bool {
+        matches!(self, Self::Reserved)
+    }
+
+    /// Gets whether the [EventType] is a valid variant.
+    pub const fn is_valid(&self) -> bool {
+        !self.is_empty()
+    }
 }
 
 impl TryFrom<u8> for EventType {

--- a/src/message/message_data/message_type/request_type.rs
+++ b/src/message/message_data/message_type/request_type.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, mem};
 
 use super::*;
 use crate::{Error, Result};
@@ -31,6 +31,26 @@ impl RequestType {
             SET_FEATURE_REQ => Self::SetFeature,
             _ => Self::Reserved,
         }
+    }
+
+    /// Converts the [RequestType] to a [`u8`].
+    pub const fn to_u8(&self) -> u8 {
+        *self as u8
+    }
+
+    /// Gets the length of the [RequestType].
+    pub const fn len() -> usize {
+        mem::size_of::<u8>()
+    }
+
+    /// Gets whether the [RequestType] contains a reserved variant.
+    pub const fn is_empty(&self) -> bool {
+        matches!(self, Self::Reserved)
+    }
+
+    /// Gets whether the [RequestType] is a valid variant.
+    pub const fn is_valid(&self) -> bool {
+        !self.is_empty()
     }
 }
 

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -1,5 +1,261 @@
 //! Contains types for additional data in request messages.
 
+use std::fmt;
+
+use crate::{
+    Error, Message, MessageCode, MessageData, MessageType, RequestCode, RequestType, Result,
+};
+
 mod stack_request;
 
 pub use stack_request::*;
+
+/// Represents an event [Message] sent by the device.
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Request {
+    request_type: RequestType,
+    request_code: RequestCode,
+    additional: Vec<u8>,
+}
+
+impl Request {
+    /// Creates a new [Request].
+    pub const fn new() -> Self {
+        Self {
+            request_type: RequestType::new(),
+            request_code: RequestCode::new(),
+            additional: Vec::new(),
+        }
+    }
+
+    /// Gets the [MessageType] of the [Request].
+    pub const fn message_type(&self) -> MessageType {
+        MessageType::Request(self.request_type)
+    }
+
+    /// Gets the [RequestType] of the [Request].
+    pub const fn request_type(&self) -> RequestType {
+        self.request_type
+    }
+
+    /// Sets the [RequestType] of the [Request].
+    pub fn set_request_type(&mut self, val: RequestType) {
+        self.request_type = val;
+    }
+
+    /// Builder function that sets the [RequestType] of the [Request].
+    pub fn with_request_type(mut self, val: RequestType) -> Self {
+        self.set_request_type(val);
+        self
+    }
+
+    /// Gets the [MessageCode] of the [Request].
+    pub const fn message_code(&self) -> MessageCode {
+        MessageCode::Request(self.request_code)
+    }
+
+    /// Gets the [RequestCode] of the [Request].
+    pub const fn request_code(&self) -> RequestCode {
+        self.request_code
+    }
+
+    /// Sets the [RequestCode] of the [Request].
+    pub fn set_request_code(&mut self, code: RequestCode) {
+        self.request_code = code;
+    }
+
+    /// Builder function that sets the [RequestCode] of the [Request].
+    pub fn with_request_code(mut self, code: RequestCode) -> Self {
+        self.set_request_code(code);
+        self
+    }
+
+    /// Gets a reference to the additional data of the [Request].
+    pub fn additional(&self) -> &[u8] {
+        &self.additional
+    }
+
+    /// Sets the additional data of the [Request].
+    pub fn set_additional(&mut self, additional: &[u8]) {
+        self.additional = additional.into();
+    }
+
+    /// Builder function that sets the additional data of the [Request].
+    pub fn with_additional(mut self, additional: &[u8]) -> Self {
+        self.set_additional(additional);
+        self
+    }
+
+    /// Gets the length of the [Message].
+    pub fn len(&self) -> usize {
+        Self::meta_len() + self.additional.len()
+    }
+
+    pub(crate) const fn meta_len() -> usize {
+        RequestType::len() + RequestCode::len()
+    }
+
+    /// Gets whether the [Request] is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.request_code.is_empty()
+    }
+
+    /// Writes the [Message] to the provided byte buffer.
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<()> {
+        let len = self.len();
+        let buf_len = buf.len();
+
+        if buf_len < len {
+            Err(Error::InvalidMessageLen((buf_len, len)))
+        } else {
+            let msg_iter = [self.request_type.to_u8()]
+                .into_iter()
+                .chain(self.request_code.to_bytes())
+                .chain(self.additional.iter().cloned());
+
+            buf.iter_mut()
+                .take(len)
+                .zip(msg_iter)
+                .for_each(|(dst, src)| *dst = src);
+
+            Ok(())
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for Request {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        let meta_len = Self::meta_len();
+        let len = val.len();
+
+        match len {
+            l if l < meta_len => Err(Error::InvalidRequestLen((len, meta_len))),
+            l if l == meta_len => Ok(Self {
+                request_type: val[0].try_into()?,
+                request_code: val[RequestType::len()..].try_into()?,
+                additional: Vec::new(),
+            }),
+            _ => Ok(Self {
+                request_type: val[0].try_into()?,
+                request_code: val[RequestType::len()..].try_into()?,
+                additional: val[Self::meta_len()..].into(),
+            }),
+        }
+    }
+}
+
+impl TryFrom<&Message> for Request {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        Ok(Self {
+            request_type: val.data().message_type().request_type()?,
+            request_code: val.data().message_code().request_code()?,
+            additional: val.data().additional().into(),
+        })
+    }
+}
+
+impl TryFrom<Message> for Request {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl From<&Request> for Message {
+    fn from(val: &Request) -> Self {
+        Self::new().with_data(
+            MessageData::new()
+                .with_message_type(val.message_type())
+                .with_message_code(val.message_code())
+                .with_additional(val.additional()),
+        )
+    }
+}
+
+impl From<Request> for Message {
+    fn from(val: Request) -> Self {
+        (&val).into()
+    }
+}
+
+impl fmt::Display for Request {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""request_type":{}, "#, self.request_type)?;
+        write!(f, r#""request_code":{}, "#, self.request_code)?;
+        write!(f, r#""additional_data": ["#)?;
+
+        for (i, d) in self.additional.iter().enumerate() {
+            if i != 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{d}")?;
+        }
+
+        write!(f, "]}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request() {
+        let type_bytes = RequestType::Operation.to_u8();
+        let code_bytes = RequestCode::Stack.to_bytes();
+
+        let raw = [type_bytes, code_bytes[0], code_bytes[1]];
+
+        let msg = Message::new().with_data(
+            MessageData::new()
+                .with_message_type(MessageType::Request(RequestType::Operation))
+                .with_message_code(MessageCode::Request(RequestCode::Stack)),
+        );
+
+        let exp = Request::new()
+            .with_request_type(RequestType::Operation)
+            .with_request_code(RequestCode::Stack);
+
+        assert_eq!(Request::try_from(raw.as_ref()), Ok(exp.clone()));
+        assert_eq!(Request::try_from(&msg), Ok(exp.clone()));
+        assert_eq!(Request::try_from(msg), Ok(exp.clone()));
+
+        let mut out = [0u8; Request::meta_len()];
+        assert_eq!(exp.to_bytes(out.as_mut()), Ok(()));
+        assert_eq!(out, raw);
+    }
+
+    #[test]
+    fn test_request_with_data() {
+        let type_bytes = RequestType::SetFeature.to_u8();
+        let code_bytes = RequestCode::Uid.to_bytes();
+        let raw = [type_bytes, code_bytes[0], code_bytes[1], 0x01];
+
+        let msg = Message::new().with_data(
+            MessageData::new()
+                .with_message_type(MessageType::Request(RequestType::SetFeature))
+                .with_message_code(MessageCode::Request(RequestCode::Uid))
+                .with_additional(raw[Request::meta_len()..].as_ref()),
+        );
+
+        let exp = Request::new()
+            .with_request_type(RequestType::SetFeature)
+            .with_request_code(RequestCode::Uid)
+            .with_additional(raw[Request::meta_len()..].as_ref());
+
+        assert_eq!(Request::try_from(raw.as_ref()), Ok(exp.clone()));
+        assert_eq!(Request::try_from(&msg), Ok(exp.clone()));
+        assert_eq!(Request::try_from(msg), Ok(exp.clone()));
+
+        let mut out = [0u8; 4];
+        assert_eq!(exp.to_bytes(out.as_mut()), Ok(()));
+        assert_eq!(out, raw);
+    }
+}


### PR DESCRIPTION
Adds the `Request` message type to represent request messages.

Various fixes for the `Event` message type, and related types.