### PR TITLE
request: add reset request type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,7 @@ pub enum Error {
     InvalidRejectCode(u8),
     InvalidRequestType(u8),
     InvalidEventType(u8),
+    InvalidMessage(((u8, u16), (u8, u16))),
     #[cfg(feature = "usb")]
     Usb(String),
 }
@@ -125,6 +126,9 @@ impl fmt::Display for Error {
             }
             Self::InvalidEventType(err) => {
                 write!(f, "invalid event type: {err:#x}")
+            }
+            Self::InvalidMessage(((have_type, have_code), (exp_type, exp_code))) => {
+                write!(f, "invalid message, have: {have_type} - {have_code}, expected: {exp_type} - {exp_code}")
             }
             #[cfg(feature = "usb")]
             Self::Usb(err) => write!(f, "USB error: {err}"),

--- a/src/message/message_data.rs
+++ b/src/message/message_data.rs
@@ -1,6 +1,6 @@
 use std::{cmp, fmt, mem};
 
-use super::MAX_LEN;
+use super::{Message, MAX_LEN};
 use crate::{Error, Result};
 
 mod conf_id;
@@ -178,6 +178,18 @@ impl From<MessageData> for Vec<u8> {
             .chain(val.message_code.to_bytes())
             .chain(val.additional)
             .collect()
+    }
+}
+
+impl From<&MessageData> for Message {
+    fn from(val: &MessageData) -> Self {
+        Message::new().with_data(val.clone())
+    }
+}
+
+impl From<MessageData> for Message {
+    fn from(val: MessageData) -> Self {
+        Message::new().with_data(val)
     }
 }
 

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -6,8 +6,10 @@ use crate::{
     Error, Message, MessageCode, MessageData, MessageType, RequestCode, RequestType, Result,
 };
 
+mod reset_request;
 mod stack_request;
 
+pub use reset_request::*;
 pub use stack_request::*;
 
 /// Represents an event [Message] sent by the device.

--- a/src/message/request/reset_request.rs
+++ b/src/message/request/reset_request.rs
@@ -1,0 +1,246 @@
+use crate::{
+    Error, Message, MessageCode, MessageData, MessageType, RequestCode, RequestType, Result,
+};
+
+/// Represents a `Reset` request message.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ResetRequest;
+
+impl ResetRequest {
+    /// Creates a new [ResetRequest].
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Gets the [MessageType] for the [ResetRequest].
+    pub const fn message_type(&self) -> MessageType {
+        MessageType::Request(self.request_type())
+    }
+
+    /// Gets the [RequestType] for the [ResetRequest].
+    pub const fn request_type(&self) -> RequestType {
+        RequestType::Operation
+    }
+
+    /// Gets the [MessageCode] for the [ResetRequest].
+    pub const fn message_code(&self) -> MessageCode {
+        MessageCode::Request(self.request_code())
+    }
+
+    /// Gets the [RequestCode] for the [ResetRequest].
+    pub const fn request_code(&self) -> RequestCode {
+        RequestCode::Reset
+    }
+}
+
+impl Default for ResetRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<ResetRequest> for Message {
+    fn from(val: ResetRequest) -> Self {
+        Message::new().with_data(val.into())
+    }
+}
+
+impl From<&ResetRequest> for Message {
+    fn from(val: &ResetRequest) -> Self {
+        (*val).into()
+    }
+}
+
+impl From<ResetRequest> for MessageData {
+    fn from(val: ResetRequest) -> Self {
+        Self::new()
+            .with_message_type(val.message_type())
+            .with_message_code(val.message_code())
+    }
+}
+
+impl From<&ResetRequest> for MessageData {
+    fn from(val: &ResetRequest) -> Self {
+        (*val).into()
+    }
+}
+
+impl TryFrom<&Message> for ResetRequest {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        val.data().try_into()
+    }
+}
+
+impl TryFrom<Message> for ResetRequest {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl TryFrom<&MessageData> for ResetRequest {
+    type Error = Error;
+
+    fn try_from(val: &MessageData) -> Result<Self> {
+        let (exp_type, exp_code) = (
+            MessageType::Request(RequestType::Operation),
+            MessageCode::Request(RequestCode::Reset),
+        );
+
+        match (val.message_type(), val.message_code()) {
+            (msg_type, msg_code) if msg_type == exp_type && msg_code == exp_code => Ok(Self),
+            (msg_type, msg_code) => Err(Error::InvalidMessage((
+                (msg_type.into(), msg_code.into()),
+                (exp_type.into(), exp_code.into()),
+            ))),
+        }
+    }
+}
+
+impl TryFrom<MessageData> for ResetRequest {
+    type Error = Error;
+
+    fn try_from(val: MessageData) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCode, EventType};
+
+    #[test]
+    fn test_reset_request() -> Result<()> {
+        let exp_type = MessageType::Request(RequestType::Operation);
+        let exp_code = MessageCode::Request(RequestCode::Reset);
+
+        let msg_data = MessageData::new()
+            .with_message_type(exp_type)
+            .with_message_code(exp_code);
+        let msg = Message::new().with_data(msg_data);
+
+        let exp_req = ResetRequest::new();
+
+        assert_eq!(exp_req.message_type(), exp_type);
+        assert_eq!(exp_type.request_type(), Ok(exp_req.request_type()));
+
+        assert_eq!(exp_req.message_code(), exp_code);
+        assert_eq!(exp_code.request_code(), Ok(exp_req.request_code()));
+
+        assert_eq!(Message::from(exp_req), msg);
+        assert_eq!(ResetRequest::try_from(&msg), Ok(exp_req));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_reset_request_data_invalid() -> Result<()> {
+        let invalid_types = [MessageType::Reserved]
+            .into_iter()
+            .chain((0x80..=0x8f).map(|m| MessageType::Event(EventType::from_u8(m))))
+            .chain(
+                [
+                    RequestType::Status,
+                    RequestType::SetFeature,
+                    RequestType::Reserved,
+                ]
+                .map(MessageType::Request),
+            )
+            .collect::<Vec<MessageType>>();
+
+        let invalid_codes = [
+            RequestCode::Uid,
+            RequestCode::ProgramSignature,
+            RequestCode::Version,
+            RequestCode::SerialNumber,
+            RequestCode::ModelName,
+            RequestCode::Status,
+            RequestCode::Stack,
+            RequestCode::Inhibit,
+            RequestCode::Collect,
+            RequestCode::Key,
+            RequestCode::EventResendInterval,
+            RequestCode::Idle,
+            RequestCode::Reject,
+            RequestCode::Hold,
+            RequestCode::AcceptorCollect,
+            RequestCode::DenominationDisable,
+            RequestCode::DirectionDisable,
+            RequestCode::CurrencyAssign,
+            RequestCode::CashBoxSize,
+            RequestCode::NearFull,
+            RequestCode::BarCode,
+            RequestCode::Insert,
+            RequestCode::ConditionalVend,
+            RequestCode::Pause,
+            RequestCode::NoteDataInfo,
+            RequestCode::RecyclerCollect,
+            RequestCode::Reserved,
+        ]
+        .map(MessageCode::Request)
+        .into_iter()
+        .chain(
+            [
+                EventCode::PowerUp,
+                EventCode::PowerUpAcceptor,
+                EventCode::PowerUpStacker,
+                EventCode::Inhibit,
+                EventCode::ProgramSignature,
+                EventCode::Rejected,
+                EventCode::Collected,
+                EventCode::Clear,
+                EventCode::OperationError,
+                EventCode::Failure,
+                EventCode::NoteStay,
+                EventCode::PowerUpAcceptorAccepting,
+                EventCode::PowerUpStackerAccepting,
+                EventCode::Idle,
+                EventCode::Escrow,
+                EventCode::VendValid,
+                EventCode::AcceptorRejected,
+                EventCode::Returned,
+                EventCode::AcceptorCollected,
+                EventCode::Insert,
+                EventCode::ConditionalVend,
+                EventCode::Pause,
+                EventCode::Resume,
+                EventCode::AcceptorClear,
+                EventCode::AcceptorOperationError,
+                EventCode::AcceptorFailure,
+                EventCode::AcceptorNoteStay,
+                EventCode::FunctionAbeyance,
+                EventCode::Reserved,
+            ]
+            .map(MessageCode::Event),
+        )
+        .collect::<Vec<MessageCode>>();
+
+        for &msg_type in invalid_types.iter() {
+            for &msg_code in invalid_codes.iter() {
+                let inval_data = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(msg_code);
+
+                let inval_type = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(ResetRequest::new().message_code());
+
+                let inval_code = MessageData::new()
+                    .with_message_type(ResetRequest::new().message_type())
+                    .with_message_code(msg_code);
+
+                for stack_data in [inval_data, inval_type, inval_code] {
+                    assert!(ResetRequest::try_from(&stack_data).is_err());
+                    assert!(ResetRequest::try_from(Message::new().with_data(stack_data)).is_err());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/tests/e2e_tests/usb.rs
+++ b/tests/e2e_tests/usb.rs
@@ -2,30 +2,26 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::{thread, time};
 
-use jcm::usb;
-use jcm::{
-    Error, Message, MessageCode, MessageData, MessageType, RequestCode, RequestType, ResponseCode,
-    Result,
-};
+use jcm::{Error, Result};
 
 use super::common;
 
 /// Dummy event responder that sends `ACK` responses to all device-sent events.
 fn ack_event_responder(
     stop: Arc<AtomicBool>,
-    event_recv: crossbeam::channel::Receiver<Message>,
-    event_res_send: crossbeam::channel::Sender<Message>,
+    event_recv: crossbeam::channel::Receiver<jcm::Message>,
+    event_res_send: crossbeam::channel::Sender<jcm::Message>,
 ) -> Result<()> {
     thread::spawn(move || -> Result<()> {
         while !stop.load(Ordering::Relaxed) {
             if let Ok(event) = event_recv.try_recv() {
                 event_res_send
                     .try_send(
-                        Message::new().with_data(
+                        jcm::Message::new().with_data(
                             event
                                 .data()
                                 .clone()
-                                .with_additional(&[ResponseCode::Ack.into()]),
+                                .with_additional(&[jcm::ResponseCode::Ack.into()]),
                         ),
                     )
                     .map_err(|err| Error::Usb(format!("error sending event response: {err}")))?;
@@ -43,14 +39,14 @@ fn ack_event_responder(
 fn test_device_status() -> Result<()> {
     let _lock = common::init()?;
 
-    let usb = Arc::new(Mutex::new(usb::UsbDeviceHandle::find_usb()?));
+    let usb = Arc::new(Mutex::new(jcm::usb::UsbDeviceHandle::find_usb()?));
     let stop = Arc::new(AtomicBool::new(false));
 
     let (event_send, event_recv) = crossbeam::channel::unbounded();
     let (response_send, response_recv) = crossbeam::channel::unbounded();
     let (event_res_send, event_res_recv) = crossbeam::channel::unbounded();
 
-    usb::poll_device_message(
+    jcm::usb::poll_device_message(
         Arc::clone(&usb),
         Arc::clone(&stop),
         event_send,
@@ -58,28 +54,28 @@ fn test_device_status() -> Result<()> {
         response_send,
     )?;
 
-    usb::wait_for_power_up(&event_recv, &event_res_send).ok();
+    jcm::usb::wait_for_power_up(&event_recv, &event_res_send).ok();
 
     ack_event_responder(Arc::clone(&stop), event_recv, event_res_send)?;
 
-    let uid_data = MessageData::new()
+    let uid_data = jcm::MessageData::new()
         .with_uid(0)
-        .with_message_type(MessageType::Request(RequestType::SetFeature))
-        .with_message_code(MessageCode::Request(RequestCode::Uid))
+        .with_message_type(jcm::MessageType::Request(jcm::RequestType::SetFeature))
+        .with_message_code(jcm::MessageCode::Request(jcm::RequestCode::Uid))
         .with_additional(&[0x1]);
 
-    let req = Message::new().with_data(uid_data);
-    let res = usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let req = jcm::Message::new().with_data(uid_data);
+    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
 
     log::info!("UID response: {res}");
 
-    let stat_data = MessageData::new()
+    let stat_data = jcm::MessageData::new()
         .with_uid(1)
-        .with_message_type(MessageType::Request(RequestType::Status))
-        .with_message_code(MessageCode::Request(RequestCode::Status));
+        .with_message_type(jcm::MessageType::Request(jcm::RequestType::Status))
+        .with_message_code(jcm::MessageCode::Request(jcm::RequestCode::Status));
 
-    let req = Message::new().with_data(stat_data);
-    let res = usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let req = jcm::Message::new().with_data(stat_data);
+    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
 
     log::debug!("Raw status response: {res}");
 
@@ -96,14 +92,14 @@ fn test_device_status() -> Result<()> {
 fn test_full_startup() -> Result<()> {
     let _lock = common::init()?;
 
-    let usb = Arc::new(Mutex::new(usb::UsbDeviceHandle::find_usb()?));
+    let usb = Arc::new(Mutex::new(jcm::usb::UsbDeviceHandle::find_usb()?));
     let stop = Arc::new(AtomicBool::new(false));
 
     let (event_send, event_recv) = crossbeam::channel::unbounded();
     let (response_send, response_recv) = crossbeam::channel::unbounded();
     let (event_res_send, event_res_recv) = crossbeam::channel::unbounded();
 
-    usb::poll_device_message(
+    jcm::usb::poll_device_message(
         Arc::clone(&usb),
         Arc::clone(&stop),
         event_send,
@@ -111,62 +107,59 @@ fn test_full_startup() -> Result<()> {
         response_send,
     )?;
 
-    usb::wait_for_power_up(&event_recv, &event_res_send).ok();
+    jcm::usb::wait_for_power_up(&event_recv, &event_res_send).ok();
 
     ack_event_responder(Arc::clone(&stop), event_recv, event_res_send)?;
 
-    let uid_data = MessageData::new()
+    let uid_data = jcm::MessageData::new()
         .with_uid(0)
-        .with_message_type(MessageType::Request(RequestType::SetFeature))
-        .with_message_code(MessageCode::Request(RequestCode::Uid))
+        .with_message_type(jcm::MessageType::Request(jcm::RequestType::SetFeature))
+        .with_message_code(jcm::MessageCode::Request(jcm::RequestCode::Uid))
         .with_additional(&[0x1]);
 
-    let req = Message::new().with_data(uid_data);
-    let res = usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let req = jcm::Message::new().with_data(uid_data);
+    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
 
     log::info!("UID response: {res}");
 
-    let stat_data = MessageData::new()
+    let stat_data = jcm::MessageData::new()
         .with_uid(1)
-        .with_message_type(MessageType::Request(RequestType::Status))
-        .with_message_code(MessageCode::Request(RequestCode::Status));
+        .with_message_type(jcm::MessageType::Request(jcm::RequestType::Status))
+        .with_message_code(jcm::MessageCode::Request(jcm::RequestCode::Status));
 
-    let req = Message::new().with_data(stat_data);
-    let res = usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let req = jcm::Message::new().with_data(stat_data);
+    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
     let res = jcm::StatusResponse::try_from(&res)?;
 
     log::info!("Status response: {res}");
 
-    let reset_data = MessageData::new()
+    let req: jcm::Message = jcm::MessageData::from(jcm::ResetRequest::new())
         .with_uid(1)
-        .with_message_type(MessageType::Request(RequestType::Operation))
-        .with_message_code(MessageCode::Request(RequestCode::Reset));
-
-    let req = Message::new().with_data(reset_data);
-    let res = usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+        .into();
+    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
 
     log::info!("Reset response: {res}");
 
-    let stat_data = MessageData::new()
+    let stat_data = jcm::MessageData::new()
         .with_uid(1)
-        .with_message_type(MessageType::Request(RequestType::Status))
-        .with_message_code(MessageCode::Request(RequestCode::Status));
+        .with_message_type(jcm::MessageType::Request(jcm::RequestType::Status))
+        .with_message_code(jcm::MessageCode::Request(jcm::RequestCode::Status));
 
-    let req = Message::new().with_data(stat_data);
-    let res = usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let req = jcm::Message::new().with_data(stat_data);
+    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
     let res = jcm::StatusResponse::try_from(&res)?;
 
     log::info!("Status response: {res}");
 
     thread::sleep(time::Duration::from_millis(5000));
 
-    let idle_data = MessageData::new()
+    let idle_data = jcm::MessageData::new()
         .with_uid(1)
-        .with_message_type(MessageType::Request(RequestType::Operation))
-        .with_message_code(MessageCode::Request(RequestCode::Idle));
+        .with_message_type(jcm::MessageType::Request(jcm::RequestType::Operation))
+        .with_message_code(jcm::MessageCode::Request(jcm::RequestCode::Idle));
 
-    let req = Message::new().with_data(idle_data);
-    let res = usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let req = jcm::Message::new().with_data(idle_data);
+    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
 
     log::info!("Idle response: {res}");
 


### PR DESCRIPTION
Adds the `ResetRequest` type to make contructing reset request messages easier. Uses type-safety to ensure correct construction.