### PR TITLE
message: add escrow event type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,14 @@ pub enum Error {
     InvalidRequestType(u8),
     InvalidEventType(u8),
     InvalidMessage(((u8, u16), (u8, u16))),
+    InvalidEscrowData,
+    InvalidCurrency((u32, u16)),
+    InvalidEscrowDataLen((usize, usize)),
+    InvalidCurrencyLen((usize, usize)),
+    InvalidDenominationLen((usize, usize)),
+    InvalidTicketLen((usize, usize)),
+    InvalidAsciiString,
+    InvalidUtf8String,
     #[cfg(feature = "usb")]
     Usb(String),
 }
@@ -130,6 +138,33 @@ impl fmt::Display for Error {
             Self::InvalidMessage(((have_type, have_code), (exp_type, exp_code))) => {
                 write!(f, "invalid message, have: {have_type} - {have_code}, expected: {exp_type} - {exp_code}")
             }
+            Self::InvalidEscrowData => write!(f, "invalid escrow data"),
+            Self::InvalidCurrency((code, denom)) => {
+                write!(
+                    f,
+                    r#"invalid currency: {{"code": {code}, "denomination": {denom}}}"#
+                )
+            }
+            Self::InvalidEscrowDataLen((have, exp)) => {
+                write!(
+                    f,
+                    "invalid escrow data length, have: {have}, expected: {exp}"
+                )
+            }
+            Self::InvalidCurrencyLen((have, exp)) => {
+                write!(f, "invalid currency length, have: {have}, expected: {exp}")
+            }
+            Self::InvalidDenominationLen((have, exp)) => {
+                write!(
+                    f,
+                    "invalid denomination length, have: {have}, expected: {exp}"
+                )
+            }
+            Self::InvalidTicketLen((have, exp)) => {
+                write!(f, "invalid ticket length, have: {have}, expected: {exp}")
+            }
+            Self::InvalidAsciiString => write!(f, "invalid ASCII encoded string"),
+            Self::InvalidUtf8String => write!(f, "invalid UTF-8 encoded string"),
             #[cfg(feature = "usb")]
             Self::Usb(err) => write!(f, "USB error: {err}"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod bill_acceptor_state;
+mod currency;
 mod denomination;
 mod device_status;
 mod error;
@@ -8,12 +9,14 @@ mod function_status;
 mod message;
 mod reject_code;
 mod status_code;
+mod ticket;
 mod unit_number;
 mod unit_status;
 #[cfg(feature = "usb")]
 pub mod usb;
 
 pub use bill_acceptor_state::*;
+pub use currency::*;
 pub use denomination::*;
 pub use device_status::*;
 pub use error::*;
@@ -23,5 +26,6 @@ pub use function_status::*;
 pub use message::*;
 pub use reject_code::*;
 pub use status_code::*;
+pub use ticket::*;
 pub use unit_number::*;
 pub use unit_status::*;

--- a/src/message/event.rs
+++ b/src/message/event.rs
@@ -2,8 +2,10 @@ use std::fmt;
 
 use crate::{Error, EventCode, EventType, Message, MessageCode, MessageData, MessageType, Result};
 
+mod escrow_event;
 mod inhibit_event;
 
+pub use escrow_event::*;
 pub use inhibit_event::*;
 
 /// Represents an event [Message] sent by the device.

--- a/src/message/event/escrow_event.rs
+++ b/src/message/event/escrow_event.rs
@@ -1,0 +1,326 @@
+use crate::{
+    Currency, Error, EventCode, EventType, Message, MessageCode, MessageData, MessageType, Result,
+    Ticket,
+};
+
+mod escrow_data;
+
+pub use escrow_data::*;
+
+/// Represents an inhibit event.
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct EscrowEvent {
+    event_type: EventType,
+    data: EscrowData,
+}
+
+impl EscrowEvent {
+    /// Creates a new [EscrowEvent].
+    pub const fn new() -> Self {
+        Self {
+            event_type: EventType::new(),
+            data: EscrowData::new(),
+        }
+    }
+
+    /// Creates a new [EscrowEvent] from the provided parameters.
+    pub const fn create(event_type: EventType, data: EscrowData) -> Self {
+        Self { event_type, data }
+    }
+
+    /// Gets the [MessageType] of the [EscrowEvent].
+    pub const fn message_type(&self) -> MessageType {
+        MessageType::Event(self.event_type())
+    }
+
+    /// Gets the [EventType] of the [EscrowEvent].
+    pub const fn event_type(&self) -> EventType {
+        self.event_type
+    }
+
+    /// Sets the [EventType] of the [EscrowEvent].
+    pub fn set_event_type(&mut self, event_type: EventType) {
+        self.event_type = event_type;
+    }
+
+    /// Builder function that sets the [EventType] of the [EscrowEvent].
+    pub fn with_event_type(mut self, event_type: EventType) -> Self {
+        self.set_event_type(event_type);
+        self
+    }
+
+    /// Gets the [MessageCode] of the [EscrowEvent].
+    pub const fn message_code(&self) -> MessageCode {
+        MessageCode::Event(self.event_code())
+    }
+
+    /// Gets the [EventCode] of the [EscrowEvent].
+    pub const fn event_code(&self) -> EventCode {
+        EventCode::Escrow
+    }
+
+    /// Gets a reference to the [EscrowData] of the [EscrowEvent].
+    pub const fn data(&self) -> &EscrowData {
+        &self.data
+    }
+
+    /// Gets a reference to the [Currency] of the [EscrowEvent].
+    pub const fn currency(&self) -> Result<&Currency> {
+        match self.data() {
+            EscrowData::Currency(data) => Ok(data),
+            _ => Err(Error::InvalidEscrowData),
+        }
+    }
+
+    /// Gets a reference to the [Ticket] of the [EscrowEvent].
+    pub const fn ticket(&self) -> Result<&Ticket> {
+        match self.data() {
+            EscrowData::Ticket(data) => Ok(data),
+            _ => Err(Error::InvalidEscrowData),
+        }
+    }
+}
+
+impl From<&EscrowEvent> for MessageData {
+    fn from(val: &EscrowEvent) -> Self {
+        MessageData::new()
+            .with_message_type(val.message_type())
+            .with_message_code(val.message_code())
+            .with_additional(val.data.to_vec().as_ref())
+    }
+}
+
+impl From<EscrowEvent> for MessageData {
+    fn from(val: EscrowEvent) -> Self {
+        (&val).into()
+    }
+}
+
+impl From<&EscrowEvent> for Message {
+    fn from(val: &EscrowEvent) -> Self {
+        MessageData::from(val).into()
+    }
+}
+
+impl From<EscrowEvent> for Message {
+    fn from(val: EscrowEvent) -> Self {
+        MessageData::from(val).into()
+    }
+}
+
+impl TryFrom<&MessageData> for EscrowEvent {
+    type Error = Error;
+
+    fn try_from(val: &MessageData) -> Result<Self> {
+        match val.message_code().event_code()? {
+            EventCode::Escrow => Ok(Self {
+                event_type: val.message_type().event_type()?,
+                data: val.additional().try_into()?,
+            }),
+            code => Err(Error::InvalidEventCode(code.into())),
+        }
+    }
+}
+
+impl TryFrom<MessageData> for EscrowEvent {
+    type Error = Error;
+
+    fn try_from(val: MessageData) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl TryFrom<&Message> for EscrowEvent {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        val.data().try_into()
+    }
+}
+
+impl TryFrom<Message> for EscrowEvent {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        val.data().try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RequestCode, RequestType};
+
+    #[test]
+    fn test_escrow_event() -> Result<()> {
+        let exp_types = (0x80..=0x8fu8)
+            .into_iter()
+            .map(|e| MessageType::Event(EventType::from_u8(e)));
+
+        let exp_code = MessageCode::Event(EventCode::Escrow);
+        let exp_data = EscrowData::new();
+
+        let mut exp_data_buf = vec![0u8; exp_data.len()];
+        exp_data.to_bytes(exp_data_buf.as_mut())?;
+
+        for exp_type in exp_types {
+            let msg: Message = MessageData::new()
+                .with_message_type(exp_type)
+                .with_message_code(exp_code)
+                .with_additional(exp_data_buf.as_ref())
+                .into();
+
+            let exp_req = EscrowEvent::create(exp_type.event_type()?, exp_data.clone());
+
+            assert_eq!(exp_req.message_type(), exp_type);
+            assert_eq!(exp_type.event_type(), Ok(exp_req.event_type()));
+
+            assert_eq!(exp_req.message_code(), exp_code);
+            assert_eq!(exp_code.event_code(), Ok(exp_req.event_code()));
+
+            assert_eq!(Message::from(&exp_req), msg);
+            assert_eq!(EscrowEvent::try_from(&msg), Ok(exp_req));
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_escrow_event_invalid() -> Result<()> {
+        let invalid_types = [MessageType::Reserved]
+            .into_iter()
+            .chain(
+                [
+                    RequestType::Operation,
+                    RequestType::Status,
+                    RequestType::SetFeature,
+                    RequestType::Reserved,
+                ]
+                .map(MessageType::Request),
+            )
+            .collect::<Vec<MessageType>>();
+
+        let invalid_codes = [
+            RequestCode::Uid,
+            RequestCode::ProgramSignature,
+            RequestCode::Version,
+            RequestCode::SerialNumber,
+            RequestCode::ModelName,
+            RequestCode::Reset,
+            RequestCode::Stack,
+            RequestCode::Status,
+            RequestCode::Inhibit,
+            RequestCode::Collect,
+            RequestCode::Key,
+            RequestCode::EventResendInterval,
+            RequestCode::Idle,
+            RequestCode::Reject,
+            RequestCode::Hold,
+            RequestCode::AcceptorCollect,
+            RequestCode::DenominationDisable,
+            RequestCode::DirectionDisable,
+            RequestCode::CurrencyAssign,
+            RequestCode::CashBoxSize,
+            RequestCode::NearFull,
+            RequestCode::BarCode,
+            RequestCode::Insert,
+            RequestCode::ConditionalVend,
+            RequestCode::Pause,
+            RequestCode::NoteDataInfo,
+            RequestCode::RecyclerCollect,
+            RequestCode::Reserved,
+        ]
+        .map(MessageCode::Request)
+        .into_iter()
+        .chain(
+            [
+                EventCode::PowerUp,
+                EventCode::PowerUpAcceptor,
+                EventCode::PowerUpStacker,
+                EventCode::ProgramSignature,
+                EventCode::Rejected,
+                EventCode::Collected,
+                EventCode::Clear,
+                EventCode::OperationError,
+                EventCode::Failure,
+                EventCode::NoteStay,
+                EventCode::PowerUpAcceptorAccepting,
+                EventCode::PowerUpStackerAccepting,
+                EventCode::Inhibit,
+                EventCode::Idle,
+                EventCode::VendValid,
+                EventCode::AcceptorRejected,
+                EventCode::Returned,
+                EventCode::AcceptorCollected,
+                EventCode::Insert,
+                EventCode::ConditionalVend,
+                EventCode::Pause,
+                EventCode::Resume,
+                EventCode::AcceptorClear,
+                EventCode::AcceptorOperationError,
+                EventCode::AcceptorFailure,
+                EventCode::AcceptorNoteStay,
+                EventCode::FunctionAbeyance,
+                EventCode::Reserved,
+            ]
+            .map(MessageCode::Event),
+        )
+        .collect::<Vec<MessageCode>>();
+
+        for &msg_type in invalid_types.iter() {
+            for &msg_code in invalid_codes.iter() {
+                let inval_data = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(msg_code);
+
+                let val_event = EscrowEvent::new();
+
+                let inval_type = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(val_event.message_code());
+
+                let inval_code = MessageData::new()
+                    .with_message_type(val_event.message_type())
+                    .with_message_code(msg_code);
+
+                let inval_currency = MessageData::new()
+                    .with_message_type(val_event.message_type())
+                    .with_message_code(val_event.message_code())
+                    .with_additional(&[b'X', b'X', b'X', 0, 1, 0, 0]);
+
+                let inval_denom = MessageData::new()
+                    .with_message_type(val_event.message_type())
+                    .with_message_code(val_event.message_code())
+                    .with_additional(&[b'J', b'P', b'Y', 0xff, 0xff, 0xff, 0xff]);
+
+                let inval_ticket_long = MessageData::new()
+                    .with_message_type(val_event.message_type())
+                    .with_message_code(val_event.message_code())
+                    .with_additional(&[0u8, 0u8, 0xff /*buffer shorter than ticket length*/]);
+
+                let inval_ticket_code = MessageData::new()
+                    .with_message_type(val_event.message_type())
+                    .with_message_code(val_event.message_code())
+                    .with_additional(&[
+                        0u8, 0u8, 9u8, 0xff, 0xb, 0xa, 0xd, b'A', b'S', b'C', b'I', b'I',
+                    ]);
+
+                for data in [
+                    inval_data,
+                    inval_type,
+                    inval_code,
+                    inval_currency,
+                    inval_denom,
+                    inval_ticket_long,
+                    inval_ticket_code,
+                ] {
+                    assert!(EscrowEvent::try_from(&data).is_err());
+                    assert!(EscrowEvent::try_from(Message::new().with_data(data)).is_err());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/message/event/escrow_event/escrow_data.rs
+++ b/src/message/event/escrow_event/escrow_data.rs
@@ -1,0 +1,113 @@
+use crate::{Currency, Error, Result, Ticket};
+
+/// Represents the minimum byte length of [EscrowData].
+pub const MIN_ESCROW_DATA_LEN: usize = 3;
+
+/// Represents the additional data of an [EscrowEvent].
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq)]
+pub enum EscrowData {
+    Currency(Currency),
+    Ticket(Ticket),
+}
+
+impl EscrowData {
+    /// Creates a new [EscrowData].
+    pub const fn new() -> Self {
+        Self::Currency(Currency::new())
+    }
+
+    /// Creates a new [EscrowData] with a [Currency] variant.
+    pub const fn new_currency(currency: Currency) -> Self {
+        Self::Currency(currency)
+    }
+
+    /// Creates a new [EscrowData] with a [Ticket] variant.
+    pub const fn new_ticket(ticket: Ticket) -> Self {
+        Self::Ticket(ticket)
+    }
+
+    /// Gets the length of the [EscrowData].
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Currency(_data) => Currency::len(),
+            Self::Ticket(data) => data.len(),
+        }
+    }
+
+    /// Gets whether the [EscrowData] is empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Currency(data) => data.is_empty(),
+            Self::Ticket(data) => data.is_empty(),
+        }
+    }
+
+    /// Writes the [EscrowData] to a byte buffer.
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<()> {
+        let len = self.len();
+        let buf_len = buf.len();
+
+        if buf_len < len {
+            Err(Error::InvalidEscrowDataLen((buf_len, len)))
+        } else {
+            match self {
+                Self::Currency(data) => data.to_bytes(buf),
+                Self::Ticket(data) => data.to_bytes(buf),
+            }
+        }
+    }
+
+    /// Converts the [EscrowData] into a byte vector.
+    pub fn to_vec(&self) -> Vec<u8> {
+        match self {
+            Self::Currency(data) => data.to_vec(),
+            Self::Ticket(data) => data.to_vec(),
+        }
+    }
+}
+
+impl TryFrom<&[u8]> for EscrowData {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        let min_len = MIN_ESCROW_DATA_LEN;
+        let val_len = val.len();
+
+        if val_len < min_len {
+            Err(Error::InvalidEscrowDataLen((val_len, min_len)))
+        } else {
+            match u16::from_le_bytes([val[0], val[1]]) {
+                0 => {
+                    let ticket_len = val[2] as usize;
+                    let exp_len = min_len + ticket_len;
+
+                    match ticket_len {
+                        t if t > 0 && val_len >= exp_len => {
+                            Ok(Self::Ticket(Ticket::try_from(val[3..3 + t].as_ref())?))
+                        }
+                        0 => Ok(Self::Ticket(Ticket::new())),
+                        _ => Err(Error::InvalidEscrowDataLen((val_len, exp_len))),
+                    }
+                }
+                _ => Ok(Self::Currency(val.try_into()?)),
+            }
+        }
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for EscrowData {
+    type Error = Error;
+
+    fn try_from(val: &[u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+
+impl<const N: usize> TryFrom<[u8; N]> for EscrowData {
+    type Error = Error;
+
+    fn try_from(val: [u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}

--- a/src/ticket.rs
+++ b/src/ticket.rs
@@ -1,0 +1,179 @@
+use std::mem;
+
+use crate::{Error, Result};
+
+/// Represents the maximum length of a [Ticket] ASCII code.
+pub const MAX_TICKET_LEN: usize = u8::MAX as usize;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TicketMetadata {
+    ticket_len: u8,
+}
+
+impl TicketMetadata {
+    /// Creates a new [TicketMetadata].
+    pub const fn new() -> Self {
+        Self { ticket_len: 0 }
+    }
+
+    /// Creates a new [TicketMetadata] from the provided parameter.
+    pub const fn create(len: usize) -> Self {
+        Self {
+            ticket_len: len as u8,
+        }
+    }
+
+    /// Gets the length of the [TicketMetadata].
+    pub const fn len() -> usize {
+        mem::size_of::<u16>() + mem::size_of::<u8>()
+    }
+
+    /// Get the length of the [Ticket] for this [TicketMetadata].
+    pub const fn ticket_len(&self) -> u8 {
+        self.ticket_len
+    }
+
+    /// Gets whether the [TicketMetadata] is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.ticket_len == 0
+    }
+
+    /// Converts the [TicketMetadata] to a byte array.
+    pub fn to_bytes(self) -> [u8; 3] {
+        [0, 0, self.ticket_len]
+    }
+}
+
+/// Represents a `ticket` handled by the JCM device.
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Ticket {
+    code: String,
+}
+
+impl Ticket {
+    /// Creates a new [Ticket].
+    pub const fn new() -> Self {
+        Self {
+            code: String::new(),
+        }
+    }
+
+    /// Gets the ASCII code of the [Ticket].
+    pub fn code(&self) -> &str {
+        self.code.as_str()
+    }
+
+    /// Sets the ASCII code of the [Ticket].
+    ///
+    /// `code` length must not exceed [MAX_LEN].
+    pub fn set_code(&mut self, code: &str) -> Result<()> {
+        if code.as_bytes().iter().any(|b| !b.is_ascii()) {
+            Err(Error::InvalidAsciiString)
+        } else {
+            match code.len() {
+                l if l <= MAX_TICKET_LEN => {
+                    self.code = code.into();
+                    Ok(())
+                }
+                l => Err(Error::InvalidTicketLen((l, MAX_TICKET_LEN))),
+            }
+        }
+    }
+
+    /// Builder function that sets the ASCII code of the [Ticket].
+    ///
+    /// `code` length must not exceed [MAX_LEN].
+    pub fn with_code(mut self, code: &str) -> Result<Self> {
+        self.set_code(code)?;
+        Ok(self)
+    }
+
+    /// Gets the [TicketMetadata] for the [Ticket].
+    pub fn metadata(&self) -> TicketMetadata {
+        TicketMetadata::create(self.code.as_bytes().len())
+    }
+
+    /// Gets the length of the metadata + ASCII code of the [Ticket].
+    pub fn len(&self) -> usize {
+        TicketMetadata::len() + self.code.as_bytes().len()
+    }
+
+    /// Gets whether the ASCII code of the [Ticket] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.code.is_empty()
+    }
+
+    /// Attempts to convert a byte buffer into a [Ticket].
+    ///
+    /// The buffer should only contain the ASCII-encode portion of the ticket.
+    pub fn from_bytes(buf: &[u8]) -> Result<Self> {
+        Self::new().with_code(std::str::from_utf8(buf).map_err(|_| Error::InvalidUtf8String)?)
+    }
+
+    /// Writes the [Ticket] to a byte buffer.
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<()> {
+        let len = self.len();
+        let buf_len = buf.len();
+
+        if buf_len < len {
+            Err(Error::InvalidTicketLen((buf_len, len)))
+        } else {
+            let ticket_iter = self
+                .metadata()
+                .to_bytes()
+                .into_iter()
+                .chain(self.code.as_bytes().iter().cloned());
+
+            buf.iter_mut()
+                .zip(ticket_iter)
+                .for_each(|(dst, src)| *dst = src);
+
+            Ok(())
+        }
+    }
+
+    /// Converts the [Ticket] into byte vector.
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut ret = vec![0u8; self.len()];
+        self.to_bytes(ret.as_mut()).ok();
+        ret
+    }
+}
+
+impl From<&Ticket> for Vec<u8> {
+    fn from(val: &Ticket) -> Self {
+        val.to_vec()
+    }
+}
+
+impl From<Ticket> for Vec<u8> {
+    fn from(val: Ticket) -> Self {
+        val.to_vec()
+    }
+}
+
+impl TryFrom<&[u8]> for Ticket {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        Self::from_bytes(val)
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for Ticket {
+    type Error = Error;
+
+    fn try_from(val: &[u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+
+impl<const N: usize> TryFrom<[u8; N]> for Ticket {
+    type Error = Error;
+
+    fn try_from(val: [u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}


### PR DESCRIPTION
Adds the `EscrowEvent` type and related types to represent device-sent escrow event messages.

Improves existing types for correctness and ergonomics.