### PR TITLE
version: bump to `v0.1.1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "jcm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "crossbeam",
  "currency-iso4217",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jcm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["JCM Rust Developers"]
 description = "Pure Rust implementation of the JCM USB communication protocol"


### PR DESCRIPTION
Bumps the patch release version to `v0.1.1` for added message types, and initial USB communication implementation.