### PR TITLE
version: bump to `0.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "jcm"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "crossbeam",
  "currency-iso4217",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jcm"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["JCM Rust Developers"]
 description = "Pure Rust implementation of the JCM USB communication protocol"


### PR DESCRIPTION
Bumps the minor release version to `v0.2.0` for additional message types, and added APIs to existing types.

Includes:

- Change `StackRequestData` to `StackRequest`
  - Add `StackRequest` accessor functions
- `Currency` accessor functions
- Add `IdleRequest` message type
- Add `InhibitRequest` message type
- Add `RejectRequest` message type
- Various code clean up and lint fixes