### PR TITLE
version: bump to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "jcm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "crossbeam",
  "currency-iso4217",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jcm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["JCM Rust Developers"]
 description = "Pure Rust implementation of the JCM USB communication protocol"


### PR DESCRIPTION
Bumps the patch release to `v0.2.1` for fixes to the `IdleRequest` and `InhibitRequest` messages.