### PR TITLE
message: version request and response types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -43,8 +43,12 @@ pub enum Error {
     InvalidCurrencyLen((usize, usize)),
     InvalidDenominationLen((usize, usize)),
     InvalidTicketLen((usize, usize)),
+    InvalidFirmwareVersionLen((usize, usize)),
+    InvalidVersionResponseLen((usize, usize)),
+    InvalidCString,
     InvalidAsciiString,
     InvalidUtf8String,
+    InvalidFirmwareVersion,
     #[cfg(feature = "usb")]
     Usb(String),
 }
@@ -163,11 +167,37 @@ impl fmt::Display for Error {
             Self::InvalidTicketLen((have, exp)) => {
                 write!(f, "invalid ticket length, have: {have}, expected: {exp}")
             }
+            Self::InvalidFirmwareVersionLen((have, exp)) => {
+                write!(
+                    f,
+                    "invalid firmware version length, have: {have}, expected: {exp}"
+                )
+            }
+            Self::InvalidVersionResponseLen((have, exp)) => {
+                write!(
+                    f,
+                    "invalid version response length, have: {have}, expected: {exp}"
+                )
+            }
             Self::InvalidAsciiString => write!(f, "invalid ASCII encoded string"),
+            Self::InvalidCString => write!(f, "invalid null-terminated C string"),
             Self::InvalidUtf8String => write!(f, "invalid UTF-8 encoded string"),
+            Self::InvalidFirmwareVersion => write!(f, "invalid firmware version"),
             #[cfg(feature = "usb")]
             Self::Usb(err) => write!(f, "USB error: {err}"),
         }
+    }
+}
+
+impl From<std::ffi::FromBytesUntilNulError> for Error {
+    fn from(_err: std::ffi::FromBytesUntilNulError) -> Self {
+        Self::InvalidCString
+    }
+}
+
+impl From<std::str::Utf8Error> for Error {
+    fn from(_err: std::str::Utf8Error) -> Self {
+        Self::InvalidUtf8String
     }
 }
 

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -14,6 +14,7 @@ mod reset_request;
 mod stack_request;
 mod status_request;
 mod uid_request;
+mod version_request;
 
 pub use idle_request::*;
 pub use inhibit_request::*;
@@ -23,6 +24,7 @@ pub use reset_request::*;
 pub use stack_request::*;
 pub use status_request::*;
 pub use uid_request::*;
+pub use version_request::*;
 
 /// Represents an event [Message] sent by the device.
 #[repr(C)]

--- a/src/message/request/version_request.rs
+++ b/src/message/request/version_request.rs
@@ -1,0 +1,251 @@
+use crate::{
+    Error, Message, MessageCode, MessageData, MessageType, RequestCode, RequestType, Result,
+};
+
+/// Represents a `Version` request message.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct VersionRequest;
+
+impl VersionRequest {
+    /// Creates a new [VersionRequest].
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Gets the [MessageType] for the [VersionRequest].
+    pub const fn message_type(&self) -> MessageType {
+        MessageType::Request(self.request_type())
+    }
+
+    /// Gets the [RequestType] for the [VersionRequest].
+    pub const fn request_type(&self) -> RequestType {
+        RequestType::Status
+    }
+
+    /// Gets the [MessageCode] for the [VersionRequest].
+    pub const fn message_code(&self) -> MessageCode {
+        MessageCode::Request(self.request_code())
+    }
+
+    /// Gets the [RequestCode] for the [VersionRequest].
+    pub const fn request_code(&self) -> RequestCode {
+        RequestCode::Version
+    }
+}
+
+impl Default for VersionRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<VersionRequest> for Message {
+    fn from(val: VersionRequest) -> Self {
+        Message::new().with_data(val.into())
+    }
+}
+
+impl From<&VersionRequest> for Message {
+    fn from(val: &VersionRequest) -> Self {
+        (*val).into()
+    }
+}
+
+impl From<VersionRequest> for MessageData {
+    fn from(val: VersionRequest) -> Self {
+        Self::new()
+            .with_message_type(val.message_type())
+            .with_message_code(val.message_code())
+    }
+}
+
+impl From<&VersionRequest> for MessageData {
+    fn from(val: &VersionRequest) -> Self {
+        (*val).into()
+    }
+}
+
+impl TryFrom<&Message> for VersionRequest {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        val.data().try_into()
+    }
+}
+
+impl TryFrom<Message> for VersionRequest {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl TryFrom<&MessageData> for VersionRequest {
+    type Error = Error;
+
+    fn try_from(val: &MessageData) -> Result<Self> {
+        let (exp_type, exp_code) = (
+            MessageType::Request(RequestType::Status),
+            MessageCode::Request(RequestCode::Version),
+        );
+
+        match (val.message_type(), val.message_code()) {
+            (msg_type, msg_code) if msg_type == exp_type && msg_code == exp_code => Ok(Self),
+            (msg_type, msg_code) => Err(Error::InvalidMessage((
+                (msg_type.into(), msg_code.into()),
+                (exp_type.into(), exp_code.into()),
+            ))),
+        }
+    }
+}
+
+impl TryFrom<MessageData> for VersionRequest {
+    type Error = Error;
+
+    fn try_from(val: MessageData) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCode, EventType};
+
+    #[test]
+    fn test_version_request() -> Result<()> {
+        let exp_type = MessageType::Request(RequestType::Status);
+        let exp_code = MessageCode::Request(RequestCode::Version);
+
+        let msg_data = MessageData::new()
+            .with_message_type(exp_type)
+            .with_message_code(exp_code);
+        let msg = Message::new().with_data(msg_data);
+
+        let exp_req = VersionRequest::new();
+
+        assert_eq!(exp_req.message_type(), exp_type);
+        assert_eq!(exp_type.request_type(), Ok(exp_req.request_type()));
+
+        assert_eq!(exp_req.message_code(), exp_code);
+        assert_eq!(exp_code.request_code(), Ok(exp_req.request_code()));
+
+        assert_eq!(Message::from(exp_req), msg);
+        assert_eq!(VersionRequest::try_from(&msg), Ok(exp_req));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_version_request_invalid() -> Result<()> {
+        let invalid_types = [MessageType::Reserved]
+            .into_iter()
+            .chain((0x80..=0x8f).map(|m| MessageType::Event(EventType::from_u8(m))))
+            .chain(
+                [
+                    RequestType::Operation,
+                    RequestType::SetFeature,
+                    RequestType::Reserved,
+                ]
+                .map(MessageType::Request),
+            )
+            .collect::<Vec<MessageType>>();
+
+        let invalid_codes = [
+            RequestCode::Uid,
+            RequestCode::ProgramSignature,
+            RequestCode::SerialNumber,
+            RequestCode::ModelName,
+            RequestCode::Status,
+            RequestCode::Stack,
+            RequestCode::Idle,
+            RequestCode::Inhibit,
+            RequestCode::Collect,
+            RequestCode::Key,
+            RequestCode::EventResendInterval,
+            RequestCode::Reset,
+            RequestCode::Reject,
+            RequestCode::Hold,
+            RequestCode::AcceptorCollect,
+            RequestCode::DenominationDisable,
+            RequestCode::DirectionDisable,
+            RequestCode::CurrencyAssign,
+            RequestCode::CashBoxSize,
+            RequestCode::NearFull,
+            RequestCode::BarCode,
+            RequestCode::Insert,
+            RequestCode::ConditionalVend,
+            RequestCode::Pause,
+            RequestCode::NoteDataInfo,
+            RequestCode::RecyclerCollect,
+            RequestCode::Reserved,
+        ]
+        .map(MessageCode::Request)
+        .into_iter()
+        .chain(
+            [
+                EventCode::PowerUp,
+                EventCode::PowerUpAcceptor,
+                EventCode::PowerUpStacker,
+                EventCode::Inhibit,
+                EventCode::ProgramSignature,
+                EventCode::Rejected,
+                EventCode::Collected,
+                EventCode::Clear,
+                EventCode::OperationError,
+                EventCode::Failure,
+                EventCode::NoteStay,
+                EventCode::PowerUpAcceptorAccepting,
+                EventCode::PowerUpStackerAccepting,
+                EventCode::Escrow,
+                EventCode::VendValid,
+                EventCode::AcceptorRejected,
+                EventCode::Returned,
+                EventCode::AcceptorCollected,
+                EventCode::Insert,
+                EventCode::ConditionalVend,
+                EventCode::Pause,
+                EventCode::Resume,
+                EventCode::AcceptorClear,
+                EventCode::AcceptorOperationError,
+                EventCode::AcceptorFailure,
+                EventCode::AcceptorNoteStay,
+                EventCode::FunctionAbeyance,
+                EventCode::Reserved,
+            ]
+            .map(MessageCode::Event),
+        )
+        .collect::<Vec<MessageCode>>();
+
+        let exp_req = VersionRequest::new();
+        let exp_type = exp_req.message_type();
+        let exp_code = exp_req.message_code();
+
+        for &msg_type in invalid_types.iter() {
+            for &msg_code in invalid_codes.iter() {
+                let inval_data = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(msg_code);
+
+                let inval_type = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(exp_code);
+
+                let inval_code = MessageData::new()
+                    .with_message_type(exp_type)
+                    .with_message_code(msg_code);
+
+                for stack_data in [inval_data, inval_type, inval_code] {
+                    assert!(VersionRequest::try_from(&stack_data).is_err());
+                    assert!(
+                        VersionRequest::try_from(Message::new().with_data(stack_data)).is_err()
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/message/response.rs
+++ b/src/message/response.rs
@@ -5,10 +5,12 @@ use crate::{Error, Message, Result};
 mod response_code;
 mod status_response;
 mod uid_response;
+mod version_response;
 
 pub use response_code::*;
 pub use status_response::*;
 pub use uid_response::*;
+pub use version_response::*;
 
 /// Represents the generic response format for JCM host-device communication.
 ///

--- a/src/message/response/response_code.rs
+++ b/src/message/response/response_code.rs
@@ -49,6 +49,11 @@ impl ResponseCode {
         }
     }
 
+    /// Converts a [ResponseCode] into a [`u8`].
+    pub const fn to_u8(&self) -> u8 {
+        *self as u8
+    }
+
     /// Gets the length of the [ResponseCode].
     pub const fn len() -> usize {
         mem::size_of::<u8>()

--- a/src/message/response/version_response.rs
+++ b/src/message/response/version_response.rs
@@ -1,0 +1,301 @@
+use std::fmt;
+
+use crate::{Error, Message, Response, ResponseCode, Result};
+
+mod firmware_version;
+
+pub use firmware_version::*;
+
+/// Represents the response to a [VersionRequest](crate::VersionRequest).
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VersionResponse {
+    code: ResponseCode,
+    firmware_version: FirmwareVersion,
+}
+
+impl VersionResponse {
+    /// Creates a new [VersionResponse].
+    pub const fn new() -> Self {
+        Self {
+            code: ResponseCode::new(),
+            firmware_version: FirmwareVersion::new(),
+        }
+    }
+
+    /// Gets the [ResponseCode] for the [VersionResponse].
+    pub const fn code(&self) -> ResponseCode {
+        self.code
+    }
+
+    /// Sets the [ResponseCode] for the [VersionResponse].
+    pub fn set_code(&mut self, code: ResponseCode) {
+        self.code = code;
+    }
+
+    /// Builder function that sets the [ResponseCode] for the [VersionResponse].
+    pub fn with_code(mut self, code: ResponseCode) -> Self {
+        self.set_code(code);
+        self
+    }
+
+    /// Gets the [FirmwareVersion] for the [VersionResponse].
+    pub const fn firmware_version(&self) -> &FirmwareVersion {
+        &self.firmware_version
+    }
+
+    /// Sets the [FirmwareVersion] for the [VersionResponse].
+    pub fn set_firmware_version(&mut self, firmware_version: FirmwareVersion) {
+        self.firmware_version = firmware_version;
+    }
+
+    /// Builder function that sets the [FirmwareVersion] for the [VersionResponse].
+    pub fn with_firmware_version(mut self, firmware_version: FirmwareVersion) -> Self {
+        self.set_firmware_version(firmware_version);
+        self
+    }
+
+    /// Gets the metadata length of the [VersionResponse].
+    pub const fn meta_len() -> usize {
+        ResponseCode::len()
+    }
+
+    /// Gets the length of the [VersionResponse].
+    pub fn len(&self) -> usize {
+        Self::meta_len() + self.firmware_version.len()
+    }
+
+    /// Gets whether the [VersionResponse] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.code.is_empty() && self.firmware_version.is_empty()
+    }
+
+    /// Attempts to convert a byte buffer into a [VersionResponse].
+    pub fn from_bytes(buf: &[u8]) -> Result<Self> {
+        let meta_len = Self::meta_len();
+        let buf_len = buf.len();
+
+        match buf_len {
+            bl if bl < meta_len => Err(Error::InvalidResponseLen((buf_len, meta_len))),
+            bl if bl == meta_len => Ok(Self {
+                code: buf[0].try_into()?,
+                firmware_version: FirmwareVersion::new(),
+            }),
+            _ => Ok(Self {
+                code: buf[0].try_into()?,
+                firmware_version: buf[1..].try_into()?,
+            }),
+        }
+    }
+
+    /// Converts the [VersionResponse] into a byte iterator.
+    pub fn iter(&self) -> impl Iterator<Item = u8> + '_ {
+        [self.code.to_u8()]
+            .into_iter()
+            .chain(self.firmware_version.iter())
+    }
+
+    /// Attempts to convert the [VersionResponse] into a byte buffer.
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<()> {
+        let len = self.len();
+        let buf_len = buf.len();
+
+        if buf_len < len {
+            Err(Error::InvalidVersionResponseLen((buf_len, len)))
+        } else {
+            buf.iter_mut()
+                .take(len)
+                .zip(self.iter())
+                .for_each(|(dst, src)| *dst = src);
+            Ok(())
+        }
+    }
+
+    /// Converts the [VersionResponse] into a byte vector.
+    pub fn into_bytes(&self) -> Vec<u8> {
+        self.iter().collect()
+    }
+}
+
+impl TryFrom<&[u8]> for VersionResponse {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        Self::from_bytes(val)
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for VersionResponse {
+    type Error = Error;
+
+    fn try_from(val: &[u8; N]) -> Result<Self> {
+        Self::from_bytes(val.as_ref())
+    }
+}
+
+impl<const N: usize> TryFrom<[u8; N]> for VersionResponse {
+    type Error = Error;
+
+    fn try_from(val: [u8; N]) -> Result<Self> {
+        Self::from_bytes(val.as_ref())
+    }
+}
+
+impl From<&VersionResponse> for Response {
+    fn from(val: &VersionResponse) -> Self {
+        Self {
+            code: val.code,
+            additional: val.firmware_version.into_bytes(),
+        }
+    }
+}
+
+impl From<VersionResponse> for Response {
+    fn from(val: VersionResponse) -> Self {
+        (&val).into()
+    }
+}
+
+impl TryFrom<&Response> for VersionResponse {
+    type Error = Error;
+
+    fn try_from(val: &Response) -> Result<Self> {
+        match val.additional().len() {
+            0 => Ok(Self {
+                code: val.code,
+                firmware_version: FirmwareVersion::new(),
+            }),
+            _ => Ok(Self {
+                code: val.code,
+                firmware_version: val.additional().try_into()?,
+            }),
+        }
+    }
+}
+
+impl TryFrom<Response> for VersionResponse {
+    type Error = Error;
+
+    fn try_from(val: Response) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl From<&VersionResponse> for Message {
+    fn from(val: &VersionResponse) -> Self {
+        use crate::{MessageData, VersionRequest};
+
+        MessageData::from(VersionRequest::new())
+            .with_additional(val.into_bytes().as_ref())
+            .into()
+    }
+}
+
+impl From<VersionResponse> for Message {
+    fn from(val: VersionResponse) -> Self {
+        (&val).into()
+    }
+}
+
+impl TryFrom<&Message> for VersionResponse {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        Response::try_from(val)?.try_into()
+    }
+}
+
+impl TryFrom<Message> for VersionResponse {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl Default for VersionResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for VersionResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""code": {}, "#, self.code())?;
+        write!(f, r#""firmware_version": {}"#, self.firmware_version())?;
+        write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_response() -> Result<()> {
+        let raw_code = ResponseCode::Ack as u8;
+        let raw_version = b"i(JPY)-100-SS 1 SomeVersion 01-25-01\0";
+        let raw: Vec<u8> = [raw_code]
+            .into_iter()
+            .chain(raw_version.iter().cloned())
+            .collect();
+
+        let exp_version = FirmwareVersion::try_from(raw_version.as_ref())?;
+
+        let exp = VersionResponse::new()
+            .with_code(ResponseCode::Ack)
+            .with_firmware_version(exp_version.clone());
+
+        let res = Response::new()
+            .with_code(ResponseCode::Ack)
+            .with_additional(raw_version.as_ref());
+
+        assert_eq!(VersionResponse::from_bytes(raw.as_ref())?, exp);
+        assert_eq!(VersionResponse::try_from(&res)?, exp);
+        assert_eq!(Response::from(&exp), res);
+
+        let out = exp.into_bytes();
+        assert_eq!(out, raw);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_version_response_invalid() -> Result<()> {
+        let raw_code = ResponseCode::Ack as u8;
+        let good_vers = FirmwareVersion::from_bytes(b"i(JPY)-100-SS 1 SomeVersion 01-25-01\0")?;
+        let bad_vers = [
+            // no date
+            b"i(JPY)-100-SS 1 SomeVersion\0".as_ref(),
+            // no date and version
+            b"i(JPY)-100-SS 1\0".as_ref(),
+            // no date, version, and interface number
+            b"i(JPY)-100-SS\0".as_ref(),
+            // no date, version, interface number, and name
+            b"\0".as_ref(),
+        ];
+
+        let exp = VersionResponse::new()
+            .with_code(ResponseCode::Ack)
+            .with_firmware_version(good_vers.clone());
+        let exp_len = exp.len();
+        let mut out = vec![0u8; exp_len];
+
+        for ver in bad_vers.into_iter() {
+            let raw: Vec<u8> = [raw_code].into_iter().chain(ver.iter().cloned()).collect();
+            assert!(VersionResponse::from_bytes(raw.as_ref()).is_err());
+            assert!(exp.to_bytes(out[..raw.len()].as_mut()).is_err());
+            assert!(exp.to_bytes(&mut []).is_err());
+            assert!(VersionResponse::try_from(Response::new().with_additional(ver)).is_err());
+            assert!(VersionResponse::try_from(
+                Response::new()
+                    .with_code(ResponseCode::Ack)
+                    .with_additional(ver)
+            )
+            .is_err());
+        }
+
+        Ok(())
+    }
+}

--- a/src/message/response/version_response/firmware_version.rs
+++ b/src/message/response/version_response/firmware_version.rs
@@ -1,0 +1,245 @@
+use std::ffi::CStr;
+use std::{fmt, mem};
+
+use crate::{Error, Result};
+
+/// Represents the firmware version from a [VersionResponse](crate::VersionResponse).
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FirmwareVersion {
+    firmware_name: String,
+    interface_number: String,
+    version: String,
+    date: String,
+}
+
+impl FirmwareVersion {
+    /// Creates a new [FirmwareVersion].
+    pub const fn new() -> Self {
+        Self {
+            firmware_name: String::new(),
+            interface_number: String::new(),
+            version: String::new(),
+            date: String::new(),
+        }
+    }
+
+    /// Gets the firmware name of the [FirmwareVersion].
+    pub fn firmware_name(&self) -> &str {
+        &self.firmware_name
+    }
+
+    /// Sets the firmware name of the [FirmwareVersion].
+    pub fn set_firmware_name(&mut self, val: &str) {
+        self.firmware_name = val.into();
+    }
+
+    /// Builder function that sets the firmware name of the [FirmwareVersion].
+    pub fn with_firmware_name(mut self, val: &str) -> Self {
+        self.set_firmware_name(val);
+        self
+    }
+
+    /// Gets the interface number of the [FirmwareVersion].
+    pub fn interface_number(&self) -> &str {
+        &self.interface_number
+    }
+
+    /// Sets the interface number of the [FirmwareVersion].
+    pub fn set_interface_number(&mut self, val: &str) {
+        self.interface_number = val.into();
+    }
+
+    /// Builder function that sets the interface number of the [FirmwareVersion].
+    pub fn with_interface_number(mut self, val: &str) -> Self {
+        self.set_interface_number(val);
+        self
+    }
+
+    /// Gets the version of the [FirmwareVersion].
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    /// Sets the version of the [FirmwareVersion].
+    pub fn set_version(&mut self, val: &str) {
+        self.version = val.into();
+    }
+
+    /// Builder function that sets the version of the [FirmwareVersion].
+    pub fn with_version(mut self, val: &str) -> Self {
+        self.set_version(val);
+        self
+    }
+
+    /// Gets the date of the [FirmwareVersion].
+    pub fn date(&self) -> &str {
+        &self.date
+    }
+
+    /// Sets the date of the [FirmwareVersion].
+    pub fn set_date(&mut self, val: &str) {
+        self.date = val.into();
+    }
+
+    /// Builder function that sets the date of the [FirmwareVersion].
+    pub fn with_date(mut self, val: &str) -> Self {
+        self.set_date(val);
+        self
+    }
+
+    /// Gets the length of the [FirmwareVersion].
+    pub fn len(&self) -> usize {
+        self.firmware_name.len()
+            + self.interface_number.len()
+            + self.version.len()
+            + self.date.len()
+            + (4 * mem::size_of::<u8>())
+    }
+
+    /// Gets whether the [FirmwareVersion] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.firmware_name.is_empty()
+            && self.interface_number.is_empty()
+            && self.version.is_empty()
+            && self.date.is_empty()
+    }
+
+    /// Attempts to convert a byte buffer into a [FirmwareVersion].
+    pub fn from_bytes(val: &[u8]) -> Result<Self> {
+        let mut ver_iter = CStr::from_bytes_until_nul(val)?.to_str()?.split(' ');
+
+        let firmware_name = ver_iter.next().ok_or(Error::InvalidFirmwareVersion)?.into();
+        let interface_number = ver_iter.next().ok_or(Error::InvalidFirmwareVersion)?.into();
+        let version = ver_iter.next().ok_or(Error::InvalidFirmwareVersion)?.into();
+        let date = ver_iter.next().ok_or(Error::InvalidFirmwareVersion)?.into();
+
+        Ok(Self {
+            firmware_name,
+            interface_number,
+            version,
+            date,
+        })
+    }
+
+    /// Converts the [FirmwareVersion] into a nul-terminated byte iterator.
+    pub fn iter(&self) -> impl Iterator<Item = u8> + '_ {
+        self.firmware_name
+            .as_bytes()
+            .iter()
+            .cloned()
+            .chain([b' '])
+            .chain(self.interface_number.as_bytes().iter().cloned())
+            .chain([b' '])
+            .chain(self.version.as_bytes().iter().cloned())
+            .chain([b' '])
+            .chain(self.date.as_bytes().iter().cloned())
+            .chain([0])
+    }
+
+    /// Attempts to convert a [FirmwareVersion] into a nul-terminated byte buffer.
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<()> {
+        let len = self.len();
+        let buf_len = buf.len();
+        if buf_len < len {
+            Err(Error::InvalidFirmwareVersionLen((buf_len, len)))
+        } else {
+            buf.iter_mut()
+                .take(len)
+                .zip(self.iter())
+                .for_each(|(dst, src)| *dst = src);
+
+            Ok(())
+        }
+    }
+
+    /// Converts the [FirmwareVersion] into a nul-terminated byte vector.
+    pub fn into_bytes(&self) -> Vec<u8> {
+        self.iter().collect()
+    }
+}
+
+impl TryFrom<&[u8]> for FirmwareVersion {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        Self::from_bytes(val)
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for FirmwareVersion {
+    type Error = Error;
+
+    fn try_from(val: &[u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+
+impl<const N: usize> TryFrom<[u8; N]> for FirmwareVersion {
+    type Error = Error;
+
+    fn try_from(val: [u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+
+impl Default for FirmwareVersion {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for FirmwareVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""firmware_name": "{}", "#, self.firmware_name())?;
+        write!(f, r#""interface_number": "{}", "#, self.interface_number())?;
+        write!(f, r#""version": "{}", "#, self.version())?;
+        write!(f, r#""date": "{}""#, self.date())?;
+        write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_firmware_version() -> Result<()> {
+        let raw = b"i(JPY)-100-SS 1 SomeVersion 01-25-01\0";
+        let exp = FirmwareVersion::try_from(raw.as_ref())?;
+
+        assert_eq!(FirmwareVersion::from_bytes(raw.as_ref())?, exp);
+
+        let out = exp.into_bytes();
+        assert_eq!(out, raw);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_firmware_version_invalid() -> Result<()> {
+        let bad_vers = [
+            // no date
+            b"i(JPY)-100-SS 1 SomeVersion\0".as_ref(),
+            // no date and version
+            b"i(JPY)-100-SS 1\0".as_ref(),
+            // no date, version, and interface number
+            b"i(JPY)-100-SS\0".as_ref(),
+            // no date, version, interface number, and name
+            b"\0".as_ref(),
+        ];
+
+        let exp = FirmwareVersion::from_bytes(b"i(JPY)-100-SS 1 SomeVersion 01-25-01\0")?;
+        let exp_len = exp.len();
+        let mut out = vec![0u8; exp_len];
+
+        for ver in bad_vers.into_iter() {
+            assert!(FirmwareVersion::from_bytes(ver).is_err());
+            assert!(exp.to_bytes(out[..ver.len()].as_mut()).is_err());
+            assert!(exp.to_bytes(&mut []).is_err());
+        }
+
+        Ok(())
+    }
+}

--- a/tests/e2e_tests/usb.rs
+++ b/tests/e2e_tests/usb.rs
@@ -133,7 +133,8 @@ fn test_full_startup() -> Result<()> {
     let req: jcm::Message = jcm::MessageData::from(jcm::VersionRequest::new())
         .with_uid(1)
         .into();
-    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let res: jcm::VersionResponse =
+        jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?.try_into()?;
 
     log::info!("Version response: {res}");
 

--- a/tests/e2e_tests/usb.rs
+++ b/tests/e2e_tests/usb.rs
@@ -130,6 +130,13 @@ fn test_full_startup() -> Result<()> {
 
     log::info!("Status response: {res}");
 
+    let req: jcm::Message = jcm::MessageData::from(jcm::VersionRequest::new())
+        .with_uid(1)
+        .into();
+    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+
+    log::info!("Version response: {res}");
+
     thread::sleep(time::Duration::from_millis(5000));
 
     let req: jcm::Message = jcm::MessageData::from(jcm::IdleRequest::new())
@@ -138,13 +145,6 @@ fn test_full_startup() -> Result<()> {
     let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
 
     log::info!("Idle response: {res}");
-
-    let req: jcm::Message = jcm::MessageData::from(jcm::InhibitRequest::new())
-        .with_uid(1)
-        .into();
-    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
-
-    log::info!("Inhibit response: {res}");
 
     stop.store(true, Ordering::SeqCst);
 


### PR DESCRIPTION
Adds `VersionRequest`, `VersionResponse` and `FirmwareVersion` types to represent request and response messages to get firmware information from the device.