### PR TITLE
version: bump to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "jcm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "crossbeam",
  "currency-iso4217",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jcm"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["JCM Rust Developers"]
 description = "Pure Rust implementation of the JCM USB communication protocol"


### PR DESCRIPTION
Bumps the patch release version to `v0.2.2` for added message types.

Includes:

- `VersionRequest`
- `VersionResponse`
- `FirmwareVersion`