### PR TITLE
request: add denomination disable request

### DIFF
--- a/src/message/message_data.rs
+++ b/src/message/message_data.rs
@@ -11,7 +11,8 @@ pub use conf_id::*;
 pub use message_code::*;
 pub use message_type::*;
 
-const MAX_DATA_LEN: usize = MAX_LEN - MessageData::meta_len();
+/// Maximum length of the [MessageData] when converted to bytes.
+pub const MAX_DATA_LEN: usize = MAX_LEN - MessageData::meta_len();
 
 /// Represents message data for JCM host-device communication.
 #[repr(C)]

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 mod collect_request;
+mod denomination_disable_request;
 mod hold_request;
 mod idle_request;
 mod inhibit_request;
@@ -19,6 +20,7 @@ mod uid_request;
 mod version_request;
 
 pub use collect_request::*;
+pub use denomination_disable_request::*;
 pub use hold_request::*;
 pub use idle_request::*;
 pub use inhibit_request::*;

--- a/src/message/request/denomination_disable_request.rs
+++ b/src/message/request/denomination_disable_request.rs
@@ -1,0 +1,416 @@
+use crate::{
+    Error, Message, MessageCode, MessageData, MessageType, RequestCode, RequestType, Result,
+    MAX_DATA_LEN,
+};
+
+mod denomination_disable;
+mod denomination_disable_mode;
+
+pub use denomination_disable::*;
+pub use denomination_disable_mode::*;
+
+/// Represents a `Denomination Disable` request message.
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DenominationDisableRequest {
+    mode: DenominationDisableMode,
+    denoms: Vec<DenominationDisable>,
+}
+
+impl DenominationDisableRequest {
+    /// Creates a new [DenominationDisableRequest].
+    pub const fn new() -> Self {
+        Self {
+            mode: DenominationDisableMode::new(),
+            denoms: Vec::new(),
+        }
+    }
+
+    /// Gets the [MessageType] for the [DenominationDisableRequest].
+    pub const fn message_type(&self) -> MessageType {
+        MessageType::Request(self.request_type())
+    }
+
+    /// Gets the [RequestType] for the [DenominationDisableRequest].
+    pub const fn request_type(&self) -> RequestType {
+        self.mode.to_request_type()
+    }
+
+    /// Gets the [DenominationDisableMode] for the [DenominationDisableRequest].
+    ///
+    /// Indirection type for setting the [RequestType].
+    pub const fn mode(&self) -> DenominationDisableMode {
+        self.mode
+    }
+
+    /// Sets the [DenominationDisableMode] for the [DenominationDisableRequest].
+    ///
+    /// Indirection type for setting the [RequestType].
+    pub fn set_mode(&mut self, mode: DenominationDisableMode) {
+        self.mode = mode;
+    }
+
+    /// Sets the [DenominationDisableMode] for the [DenominationDisableRequest].
+    ///
+    /// Indirection type for setting the [RequestType].
+    pub fn with_mode(mut self, mode: DenominationDisableMode) -> Self {
+        self.set_mode(mode);
+        self
+    }
+
+    /// Gets the [MessageCode] for the [DenominationDisableRequest].
+    pub const fn message_code(&self) -> MessageCode {
+        MessageCode::Request(self.request_code())
+    }
+
+    /// Gets the [RequestCode] for the [DenominationDisableRequest].
+    pub const fn request_code(&self) -> RequestCode {
+        RequestCode::DenominationDisable
+    }
+
+    /// Gets the maximum denomination index.
+    pub fn max_denom() -> usize {
+        Self::max_denom_len() - 1
+    }
+
+    /// Gets the maximum number of denominations.
+    pub fn max_denom_len() -> usize {
+        MAX_DATA_LEN.saturating_mul(DenominationDisable::denom_len())
+    }
+
+    /// Gets the current maximum denomination index
+    pub fn cur_max_denom(&self) -> usize {
+        self.cur_max_denom_len() - 1
+    }
+
+    /// Gets the current maximum denomination index
+    pub fn cur_max_denom_len(&self) -> usize {
+        self.denoms
+            .len()
+            .saturating_mul(DenominationDisable::denom_len())
+    }
+
+    /// Gets a reference to the list of [DenominationDisable] items.
+    pub fn denominations(&self) -> &[DenominationDisable] {
+        self.denoms.as_ref()
+    }
+
+    /// Sets the list of [DenominationDisable] items.
+    pub fn set_denominations(&mut self, denoms: &[DenominationDisable]) -> Result<()> {
+        let denom_len = denoms
+            .len()
+            .saturating_mul(DenominationDisable::denom_len());
+        if denom_len > Self::max_denom_len() {
+            Err(Error::InvalidDenominationLen((
+                denom_len,
+                Self::max_denom_len(),
+            )))
+        } else {
+            self.denoms = denoms.into();
+            Ok(())
+        }
+    }
+
+    /// Builder function that sets the list of [DenominationDisable] items.
+    pub fn with_denominations(mut self, denoms: &[DenominationDisable]) -> Result<Self> {
+        self.set_denominations(denoms)?;
+        Ok(self)
+    }
+
+    /// Sets a denomination disabled status.
+    ///
+    /// ## Parameters
+    ///
+    /// - `idx`: denomination index to set.
+    /// - `disable`: whether to disable the denomination.
+    pub(crate) fn set_denomination(&mut self, idx: usize, disable: bool) -> Result<()> {
+        const DENOM_LEN: usize = DenominationDisable::denom_len();
+
+        if idx > Self::max_denom() {
+            Err(Error::InvalidDenominationLen((idx, Self::max_denom())))
+        } else if idx > self.cur_max_denom() {
+            // get the number of blank denomination sets to add
+            let add = (idx / DENOM_LEN).saturating_sub(self.denoms.len());
+            let denom_idx = idx % DENOM_LEN;
+
+            self.denoms.append(
+                &mut (0..add)
+                    .map(|_| DenominationDisable::new())
+                    .chain([DenominationDisable::new().with_set(denom_idx, disable)])
+                    .collect(),
+            );
+
+            Ok(())
+        } else {
+            let item_idx = idx / DENOM_LEN;
+            let denom_idx = idx % DENOM_LEN;
+
+            self.denoms[item_idx].set(denom_idx, disable);
+
+            Ok(())
+        }
+    }
+
+    /// Disables a denomination at the given index.
+    pub fn disable_denomination(&mut self, idx: usize) -> Result<()> {
+        self.set_denomination(idx, true)
+    }
+
+    /// Enables a denomination at the given index.
+    pub fn enable_denomination(&mut self, idx: usize) -> Result<()> {
+        self.set_denomination(idx, false)
+    }
+}
+
+impl Default for DenominationDisableRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<&DenominationDisableRequest> for Message {
+    fn from(val: &DenominationDisableRequest) -> Self {
+        MessageData::from(val).into()
+    }
+}
+
+impl From<DenominationDisableRequest> for Message {
+    fn from(val: DenominationDisableRequest) -> Self {
+        (&val).into()
+    }
+}
+
+impl From<&DenominationDisableRequest> for MessageData {
+    fn from(val: &DenominationDisableRequest) -> Self {
+        let data = Self::new()
+            .with_message_type(val.message_type())
+            .with_message_code(val.message_code());
+        match val.mode() {
+            DenominationDisableMode::Set => data.with_additional(
+                val.denoms
+                    .iter()
+                    .flat_map(|d| d.to_bytes())
+                    .collect::<Vec<u8>>()
+                    .as_ref(),
+            ),
+            _ => data,
+        }
+    }
+}
+
+impl From<DenominationDisableRequest> for MessageData {
+    fn from(val: DenominationDisableRequest) -> Self {
+        (&val).into()
+    }
+}
+
+impl TryFrom<&Message> for DenominationDisableRequest {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        val.data().try_into()
+    }
+}
+
+impl TryFrom<Message> for DenominationDisableRequest {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl TryFrom<&MessageData> for DenominationDisableRequest {
+    type Error = Error;
+
+    fn try_from(val: &MessageData) -> Result<Self> {
+        let (exp_type, exp_code) = (
+            MessageType::Request(RequestType::Status),
+            MessageCode::Request(RequestCode::DenominationDisable),
+        );
+
+        // Be generous with data returned by the device.
+        // Don't worry about data that isn't a multiple of `DenominationDisable::len()` bytes.
+        let denoms = val
+            .additional()
+            .chunks(DenominationDisable::len())
+            .map(DenominationDisable::from_bytes)
+            .collect();
+
+        match (val.message_type().request_type(), val.message_code()) {
+            (Ok(msg_type), msg_code)
+                if matches!(msg_type, RequestType::Status | RequestType::SetFeature)
+                    && msg_code == exp_code =>
+            {
+                Ok(Self {
+                    mode: msg_type.try_into()?,
+                    denoms,
+                })
+            }
+            (_, msg_code) => Err(Error::InvalidMessage((
+                (val.message_type().into(), msg_code.into()),
+                (exp_type.into(), exp_code.into()),
+            ))),
+        }
+    }
+}
+
+impl TryFrom<MessageData> for DenominationDisableRequest {
+    type Error = Error;
+
+    fn try_from(val: MessageData) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCode, EventType};
+
+    #[test]
+    fn test_status_request() -> Result<()> {
+        let exp_code = RequestCode::DenominationDisable;
+        let exp_denom = DenominationDisable::new();
+
+        for exp_type in [RequestType::Status, RequestType::SetFeature] {
+            let (msg_data, exp_req) = if exp_type == RequestType::SetFeature {
+                (
+                    MessageData::new()
+                        .with_message_type(MessageType::Request(exp_type))
+                        .with_message_code(MessageCode::Request(exp_code))
+                        .with_additional(exp_denom.to_bytes().as_ref()),
+                    DenominationDisableRequest::new()
+                        .with_mode(DenominationDisableMode::from_request_type(exp_type))
+                        .with_denominations(&[exp_denom])?,
+                )
+            } else {
+                (
+                    MessageData::new()
+                        .with_message_type(MessageType::Request(exp_type))
+                        .with_message_code(MessageCode::Request(exp_code)),
+                    DenominationDisableRequest::new()
+                        .with_mode(DenominationDisableMode::from_request_type(exp_type)),
+                )
+            };
+
+            let msg = Message::new().with_data(msg_data);
+
+            assert_eq!(exp_req.message_type().request_type(), Ok(exp_type));
+            assert_eq!(exp_req.request_type(), exp_type);
+
+            assert_eq!(exp_req.message_code().request_code(), Ok(exp_code));
+            assert_eq!(exp_req.request_code(), exp_code);
+
+            assert_eq!(Message::from(&exp_req), msg);
+            assert_eq!(
+                DenominationDisableRequest::try_from(&msg).as_ref(),
+                Ok(&exp_req)
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_status_request_invalid() -> Result<()> {
+        let invalid_types = [MessageType::Reserved]
+            .into_iter()
+            .chain((0x80..=0x8f).map(|m| MessageType::Event(EventType::from_u8(m))))
+            .chain([RequestType::Operation, RequestType::Reserved].map(MessageType::Request))
+            .collect::<Vec<MessageType>>();
+
+        let invalid_codes = [
+            RequestCode::Uid,
+            RequestCode::ProgramSignature,
+            RequestCode::Version,
+            RequestCode::SerialNumber,
+            RequestCode::ModelName,
+            RequestCode::Reset,
+            RequestCode::Stack,
+            RequestCode::Inhibit,
+            RequestCode::Collect,
+            RequestCode::Key,
+            RequestCode::EventResendInterval,
+            RequestCode::Idle,
+            RequestCode::Reject,
+            RequestCode::Hold,
+            RequestCode::AcceptorCollect,
+            RequestCode::Status,
+            RequestCode::DirectionDisable,
+            RequestCode::CurrencyAssign,
+            RequestCode::CashBoxSize,
+            RequestCode::NearFull,
+            RequestCode::BarCode,
+            RequestCode::Insert,
+            RequestCode::ConditionalVend,
+            RequestCode::Pause,
+            RequestCode::NoteDataInfo,
+            RequestCode::RecyclerCollect,
+            RequestCode::Reserved,
+        ]
+        .map(MessageCode::Request)
+        .into_iter()
+        .chain(
+            [
+                EventCode::PowerUp,
+                EventCode::PowerUpAcceptor,
+                EventCode::PowerUpStacker,
+                EventCode::Inhibit,
+                EventCode::ProgramSignature,
+                EventCode::Rejected,
+                EventCode::Collected,
+                EventCode::Clear,
+                EventCode::OperationError,
+                EventCode::Failure,
+                EventCode::NoteStay,
+                EventCode::PowerUpAcceptorAccepting,
+                EventCode::PowerUpStackerAccepting,
+                EventCode::Idle,
+                EventCode::Escrow,
+                EventCode::VendValid,
+                EventCode::AcceptorRejected,
+                EventCode::Returned,
+                EventCode::AcceptorCollected,
+                EventCode::Insert,
+                EventCode::ConditionalVend,
+                EventCode::Pause,
+                EventCode::Resume,
+                EventCode::AcceptorClear,
+                EventCode::AcceptorOperationError,
+                EventCode::AcceptorFailure,
+                EventCode::AcceptorNoteStay,
+                EventCode::FunctionAbeyance,
+                EventCode::Reserved,
+            ]
+            .map(MessageCode::Event),
+        )
+        .collect::<Vec<MessageCode>>();
+
+        for &msg_type in invalid_types.iter() {
+            for &msg_code in invalid_codes.iter() {
+                let inval_data = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(msg_code);
+
+                let inval_type = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(DenominationDisableRequest::new().message_code());
+
+                let inval_code = MessageData::new()
+                    .with_message_type(DenominationDisableRequest::new().message_type())
+                    .with_message_code(msg_code);
+
+                for stack_data in [inval_data, inval_type, inval_code] {
+                    assert!(DenominationDisableRequest::try_from(&stack_data).is_err());
+                    assert!(DenominationDisableRequest::try_from(
+                        Message::new().with_data(stack_data)
+                    )
+                    .is_err());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/message/request/denomination_disable_request/denomination_disable.rs
+++ b/src/message/request/denomination_disable_request/denomination_disable.rs
@@ -1,0 +1,155 @@
+use crate::{Error, Result};
+
+/// Represents a set of denominations to disable on the device.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DenominationDisable(u16);
+
+impl DenominationDisable {
+    /// Creates a new [DenominationDisable].
+    pub const fn new() -> Self {
+        Self(0)
+    }
+
+    /// Creates a new [DenominationDisable] from the provided parameter.
+    pub const fn create(val: u16) -> Self {
+        Self(val)
+    }
+
+    /// Converts the [DenominationDisable] into its inner representation.
+    pub const fn inner(&self) -> u16 {
+        self.0
+    }
+
+    /// Consumes and converts the [DenominationDisable] into its inner representation.
+    pub const fn into_inner(self) -> u16 {
+        self.0
+    }
+
+    /// Gets the length of the [DenominationDisable].
+    pub const fn len() -> usize {
+        std::mem::size_of::<u16>()
+    }
+
+    /// Gets whether the [DenominationDisable] is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+
+    /// Gets the maximum denomination index for the [DenominationDisable].
+    pub const fn max_denom() -> usize {
+        Self::denom_len() - 1
+    }
+
+    /// Gets the number of denominations.
+    pub const fn denom_len() -> usize {
+        u16::BITS as usize
+    }
+
+    /// Gets whether a denomination is disabled.
+    pub const fn is_disabled(&self, idx: usize) -> bool {
+        if idx > Self::max_denom() {
+            false
+        } else {
+            self.0 & (1 << idx) != 0
+        }
+    }
+
+    /// Gets whether a denomination is enabled.
+    pub const fn is_enabled(&self, idx: usize) -> bool {
+        if idx > Self::max_denom() {
+            false
+        } else {
+            self.0 & (1 << idx) == 0
+        }
+    }
+
+    /// Sets whether the denomination is disabled.
+    pub(crate) fn set(&mut self, idx: usize, disable: bool) {
+        if disable {
+            self.0 |= 1 << idx;
+        } else {
+            self.0 &= !(1 << idx);
+        }
+    }
+
+    /// Builder function that sets whether the denomination is disabled.
+    pub(crate) fn with_set(mut self, idx: usize, disable: bool) -> Self {
+        self.set(idx, disable);
+        self
+    }
+
+    /// Enables a denomination.
+    pub fn enable(&mut self, idx: usize) {
+        if idx <= Self::max_denom() {
+            self.set(idx, false);
+        }
+    }
+
+    /// Builder function that enables a denomination.
+    pub fn with_enable(mut self, idx: usize) -> Self {
+        self.enable(idx);
+        self
+    }
+
+    /// Disables a denomination.
+    pub fn disable(&mut self, idx: usize) {
+        if idx <= Self::max_denom() {
+            self.set(idx, true);
+        }
+    }
+
+    /// Builder function that disables a denomination.
+    pub fn with_disable(mut self, idx: usize) -> Self {
+        self.disable(idx);
+        self
+    }
+
+    /// Infallible conversion from byte buffer into a [DenominationDisable].
+    pub fn from_bytes(val: &[u8]) -> Self {
+        match val.len() {
+            0 => Self::new(),
+            1 => Self(u16::from_le_bytes([val[0], 0])),
+            _ => Self(u16::from_le_bytes([val[0], val[1]])),
+        }
+    }
+
+    /// Converts the [DenominationDisable] into a byte array.
+    pub fn to_bytes(&self) -> [u8; 2] {
+        self.0.to_le_bytes()
+    }
+
+    /// Consumes and converts the [DenominationDisable] into a byte array.
+    pub fn into_bytes(self) -> [u8; 2] {
+        self.0.to_le_bytes()
+    }
+}
+
+impl Default for DenominationDisable {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&[u8]> for DenominationDisable {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        match val.len() {
+            2 => Ok(Self::from_bytes(val)),
+            len => Err(Error::InvalidRequestLen((len, Self::len()))),
+        }
+    }
+}
+
+impl From<DenominationDisable> for [u8; 2] {
+    fn from(val: DenominationDisable) -> Self {
+        val.into_bytes()
+    }
+}
+
+impl From<&DenominationDisable> for [u8; 2] {
+    fn from(val: &DenominationDisable) -> Self {
+        val.to_bytes()
+    }
+}

--- a/src/message/request/denomination_disable_request/denomination_disable_mode.rs
+++ b/src/message/request/denomination_disable_request/denomination_disable_mode.rs
@@ -1,0 +1,77 @@
+use crate::{Error, RequestType, Result};
+
+/// Represents the request mode for the [DenominationDisableRequest].
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DenominationDisableMode {
+    Get = 0,
+    Set = 1,
+    Reserved = 0xff,
+}
+
+impl DenominationDisableMode {
+    /// Creates a new [DenominationDisableMode].
+    pub const fn new() -> Self {
+        Self::Get
+    }
+
+    pub const fn from_request_type(val: RequestType) -> Self {
+        match val {
+            RequestType::Status => Self::Get,
+            RequestType::SetFeature => Self::Set,
+            _ => Self::Reserved,
+        }
+    }
+
+    pub const fn to_request_type(&self) -> RequestType {
+        match self {
+            Self::Get => RequestType::Status,
+            Self::Set => RequestType::SetFeature,
+            Self::Reserved => RequestType::Reserved,
+        }
+    }
+}
+
+impl TryFrom<DenominationDisableMode> for RequestType {
+    type Error = Error;
+
+    fn try_from(val: DenominationDisableMode) -> Result<Self> {
+        match val.to_request_type() {
+            Self::Reserved => Err(Error::InvalidRequestType(Self::Reserved.to_u8())),
+            req => Ok(req),
+        }
+    }
+}
+
+impl TryFrom<&DenominationDisableMode> for RequestType {
+    type Error = Error;
+
+    fn try_from(val: &DenominationDisableMode) -> Result<Self> {
+        (*val).try_into()
+    }
+}
+
+impl TryFrom<RequestType> for DenominationDisableMode {
+    type Error = Error;
+
+    fn try_from(val: RequestType) -> Result<Self> {
+        match Self::from_request_type(val) {
+            Self::Reserved => Err(Error::InvalidRequestType(val.to_u8())),
+            mode => Ok(mode),
+        }
+    }
+}
+
+impl TryFrom<&RequestType> for DenominationDisableMode {
+    type Error = Error;
+
+    fn try_from(val: &RequestType) -> Result<Self> {
+        (*val).try_into()
+    }
+}
+
+impl Default for DenominationDisableMode {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
Adds the `DenominationDisableRequest`, `DenominationDisable`, and `DenominationDisableMode` types for making requests to disable denominations on the device.