### PR TITLE
message: currency assign request and response types

### DIFF
--- a/src/currency.rs
+++ b/src/currency.rs
@@ -4,6 +4,9 @@ pub use currency_iso4217::Currency as CurrencyCode;
 
 use crate::{Denomination, Error, Result};
 
+/// Represents the length in bytes of the [Currency].
+pub const CURRENCY_LEN: usize = 5;
+
 /// Represents device currency code and denomination.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -94,11 +97,19 @@ impl Currency {
         }
     }
 
+    /// Converts the [Currency] into a byte array.
+    pub fn into_bytes(&self) -> [u8; CURRENCY_LEN] {
+        let mut buf = [0u8; CURRENCY_LEN];
+        buf[..CurrencyCode::LEN].copy_from_slice(<&str>::from(self.code).as_bytes());
+        self.denomination
+            .to_bytes(&mut buf[CurrencyCode::LEN..])
+            .ok();
+        buf
+    }
+
     /// Converts the [Currency] into byte vector.
     pub fn to_vec(&self) -> Vec<u8> {
-        let mut ret = [0u8; Self::len()];
-        self.to_bytes(ret.as_mut()).ok();
-        ret.into()
+        self.into_bytes().into()
     }
 }
 

--- a/src/denomination.rs
+++ b/src/denomination.rs
@@ -6,6 +6,9 @@ const DENOM_INT_SHIFT: u8 = 8;
 const DENOM_EXP_MAX: u32 = 19;
 const DENOM_BASE: u64 = 10;
 
+/// Represents the byte length of the [Denomination].
+pub const DENOM_LEN: usize = 2;
+
 /// Represents the currency denomination.
 ///
 /// ## Format
@@ -140,6 +143,11 @@ impl Denomination {
             buf.copy_from_slice(self.to_u16().to_be_bytes().as_ref());
             Ok(())
         }
+    }
+
+    /// Converts a [Denomination] into a byte array.
+    pub const fn into_bytes(self) -> [u8; DENOM_LEN] {
+        self.to_u16().to_be_bytes()
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,7 @@ pub enum Error {
     InvalidTicketLen((usize, usize)),
     InvalidFirmwareVersionLen((usize, usize)),
     InvalidVersionResponseLen((usize, usize)),
+    InvalidCurrencyAssignLen((usize, usize)),
     InvalidCString,
     InvalidAsciiString,
     InvalidUtf8String,
@@ -177,6 +178,12 @@ impl fmt::Display for Error {
                 write!(
                     f,
                     "invalid version response length, have: {have}, expected: {exp}"
+                )
+            }
+            Self::InvalidCurrencyAssignLen((have, exp)) => {
+                write!(
+                    f,
+                    "invalid currency assign length, have: {have}, expected: {exp}"
                 )
             }
             Self::InvalidAsciiString => write!(f, "invalid ASCII encoded string"),

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 mod collect_request;
+mod currency_assign_request;
 mod denomination_disable_request;
 mod direction_disable_request;
 mod hold_request;
@@ -21,6 +22,7 @@ mod uid_request;
 mod version_request;
 
 pub use collect_request::*;
+pub use currency_assign_request::*;
 pub use denomination_disable_request::*;
 pub use direction_disable_request::*;
 pub use hold_request::*;

--- a/src/message/request/currency_assign_request.rs
+++ b/src/message/request/currency_assign_request.rs
@@ -1,0 +1,249 @@
+use crate::{
+    Error, Message, MessageCode, MessageData, MessageType, RequestCode, RequestType, Result,
+};
+
+/// Represents a `Status` request message.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CurrencyAssignRequest;
+
+impl CurrencyAssignRequest {
+    /// Creates a new [CurrencyAssignRequest].
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Gets the [MessageType] for the [CurrencyAssignRequest].
+    pub const fn message_type(&self) -> MessageType {
+        MessageType::Request(self.request_type())
+    }
+
+    /// Gets the [RequestType] for the [CurrencyAssignRequest].
+    pub const fn request_type(&self) -> RequestType {
+        RequestType::Status
+    }
+
+    /// Gets the [MessageCode] for the [CurrencyAssignRequest].
+    pub const fn message_code(&self) -> MessageCode {
+        MessageCode::Request(self.request_code())
+    }
+
+    /// Gets the [RequestCode] for the [CurrencyAssignRequest].
+    pub const fn request_code(&self) -> RequestCode {
+        RequestCode::CurrencyAssign
+    }
+}
+
+impl Default for CurrencyAssignRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<CurrencyAssignRequest> for Message {
+    fn from(val: CurrencyAssignRequest) -> Self {
+        MessageData::from(val).into()
+    }
+}
+
+impl From<&CurrencyAssignRequest> for Message {
+    fn from(val: &CurrencyAssignRequest) -> Self {
+        (*val).into()
+    }
+}
+
+impl From<CurrencyAssignRequest> for MessageData {
+    fn from(val: CurrencyAssignRequest) -> Self {
+        Self::new()
+            .with_message_type(val.message_type())
+            .with_message_code(val.message_code())
+    }
+}
+
+impl From<&CurrencyAssignRequest> for MessageData {
+    fn from(val: &CurrencyAssignRequest) -> Self {
+        (*val).into()
+    }
+}
+
+impl TryFrom<&Message> for CurrencyAssignRequest {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        val.data().try_into()
+    }
+}
+
+impl TryFrom<Message> for CurrencyAssignRequest {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl TryFrom<&MessageData> for CurrencyAssignRequest {
+    type Error = Error;
+
+    fn try_from(val: &MessageData) -> Result<Self> {
+        let (exp_type, exp_code) = (
+            MessageType::Request(RequestType::Status),
+            MessageCode::Request(RequestCode::CurrencyAssign),
+        );
+
+        match (val.message_type(), val.message_code()) {
+            (msg_type, msg_code) if msg_type == exp_type && msg_code == exp_code => Ok(Self),
+            (msg_type, msg_code) => Err(Error::InvalidMessage((
+                (msg_type.into(), msg_code.into()),
+                (exp_type.into(), exp_code.into()),
+            ))),
+        }
+    }
+}
+
+impl TryFrom<MessageData> for CurrencyAssignRequest {
+    type Error = Error;
+
+    fn try_from(val: MessageData) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCode, EventType};
+
+    #[test]
+    fn test_currency_assign_request() -> Result<()> {
+        let exp_type = MessageType::Request(RequestType::Status);
+        let exp_code = MessageCode::Request(RequestCode::CurrencyAssign);
+
+        let msg_data = MessageData::new()
+            .with_message_type(exp_type)
+            .with_message_code(exp_code);
+        let msg = Message::new().with_data(msg_data);
+
+        let exp_req = CurrencyAssignRequest::new();
+
+        assert_eq!(exp_req.message_type(), exp_type);
+        assert_eq!(exp_type.request_type(), Ok(exp_req.request_type()));
+
+        assert_eq!(exp_req.message_code(), exp_code);
+        assert_eq!(exp_code.request_code(), Ok(exp_req.request_code()));
+
+        assert_eq!(Message::from(exp_req), msg);
+        assert_eq!(CurrencyAssignRequest::try_from(&msg), Ok(exp_req));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_currency_assign_request_invalid() -> Result<()> {
+        let invalid_types = [MessageType::Reserved]
+            .into_iter()
+            .chain((0x80..=0x8f).map(|m| MessageType::Event(EventType::from_u8(m))))
+            .chain(
+                [
+                    RequestType::Operation,
+                    RequestType::SetFeature,
+                    RequestType::Reserved,
+                ]
+                .map(MessageType::Request),
+            )
+            .collect::<Vec<MessageType>>();
+
+        let invalid_codes = [
+            RequestCode::Uid,
+            RequestCode::ProgramSignature,
+            RequestCode::Version,
+            RequestCode::SerialNumber,
+            RequestCode::ModelName,
+            RequestCode::Reset,
+            RequestCode::Stack,
+            RequestCode::Inhibit,
+            RequestCode::Collect,
+            RequestCode::Key,
+            RequestCode::EventResendInterval,
+            RequestCode::Idle,
+            RequestCode::Reject,
+            RequestCode::Hold,
+            RequestCode::AcceptorCollect,
+            RequestCode::DenominationDisable,
+            RequestCode::DirectionDisable,
+            RequestCode::Status,
+            RequestCode::CashBoxSize,
+            RequestCode::NearFull,
+            RequestCode::BarCode,
+            RequestCode::Insert,
+            RequestCode::ConditionalVend,
+            RequestCode::Pause,
+            RequestCode::NoteDataInfo,
+            RequestCode::RecyclerCollect,
+            RequestCode::Reserved,
+        ]
+        .map(MessageCode::Request)
+        .into_iter()
+        .chain(
+            [
+                EventCode::PowerUp,
+                EventCode::PowerUpAcceptor,
+                EventCode::PowerUpStacker,
+                EventCode::Inhibit,
+                EventCode::ProgramSignature,
+                EventCode::Rejected,
+                EventCode::Collected,
+                EventCode::Clear,
+                EventCode::OperationError,
+                EventCode::Failure,
+                EventCode::NoteStay,
+                EventCode::PowerUpAcceptorAccepting,
+                EventCode::PowerUpStackerAccepting,
+                EventCode::Idle,
+                EventCode::Escrow,
+                EventCode::VendValid,
+                EventCode::AcceptorRejected,
+                EventCode::Returned,
+                EventCode::AcceptorCollected,
+                EventCode::Insert,
+                EventCode::ConditionalVend,
+                EventCode::Pause,
+                EventCode::Resume,
+                EventCode::AcceptorClear,
+                EventCode::AcceptorOperationError,
+                EventCode::AcceptorFailure,
+                EventCode::AcceptorNoteStay,
+                EventCode::FunctionAbeyance,
+                EventCode::Reserved,
+            ]
+            .map(MessageCode::Event),
+        )
+        .collect::<Vec<MessageCode>>();
+
+        for &msg_type in invalid_types.iter() {
+            for &msg_code in invalid_codes.iter() {
+                let inval_data = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(msg_code);
+
+                let inval_type = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(CurrencyAssignRequest::new().message_code());
+
+                let inval_code = MessageData::new()
+                    .with_message_type(CurrencyAssignRequest::new().message_type())
+                    .with_message_code(msg_code);
+
+                for stack_data in [inval_data, inval_type, inval_code] {
+                    assert!(CurrencyAssignRequest::try_from(&stack_data).is_err());
+                    assert!(
+                        CurrencyAssignRequest::try_from(Message::new().with_data(stack_data))
+                            .is_err()
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/message/response.rs
+++ b/src/message/response.rs
@@ -2,11 +2,13 @@ use std::fmt;
 
 use crate::{Error, Message, Result};
 
+mod currency_assign_response;
 mod response_code;
 mod status_response;
 mod uid_response;
 mod version_response;
 
+pub use currency_assign_response::*;
 pub use response_code::*;
 pub use status_response::*;
 pub use uid_response::*;

--- a/src/message/response/currency_assign_response.rs
+++ b/src/message/response/currency_assign_response.rs
@@ -1,0 +1,265 @@
+use std::fmt;
+
+use crate::{Error, Message, Response, ResponseCode, Result};
+
+mod currency_assign;
+
+pub use currency_assign::*;
+
+/// Represents the [Response] to a UID request [Message](crate::Message).
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CurrencyAssignResponse {
+    code: ResponseCode,
+    currency_assign: CurrencyAssignList,
+}
+
+impl CurrencyAssignResponse {
+    /// Creates a new [CurrencyAssignResponse].
+    pub const fn new() -> Self {
+        Self {
+            code: ResponseCode::new(),
+            currency_assign: CurrencyAssignList::new(),
+        }
+    }
+
+    /// Gets the [ResponseCode] for the [CurrencyAssignResponse].
+    pub const fn code(&self) -> ResponseCode {
+        self.code
+    }
+
+    /// Sets the [ResponseCode] for the [CurrencyAssignResponse].
+    pub fn set_code(&mut self, code: ResponseCode) {
+        self.code = code;
+    }
+
+    /// Builder function that sets the [ResponseCode] for the [CurrencyAssignResponse].
+    pub fn with_code(mut self, code: ResponseCode) -> Self {
+        self.set_code(code);
+        self
+    }
+
+    /// Gets a reference to the list of [CurrencyAssign] items.
+    pub fn currency_assign(&self) -> &[CurrencyAssign] {
+        self.currency_assign.items()
+    }
+
+    /// Sets the list of [CurrencyAssign] items.
+    pub fn set_currency_assign(&mut self, val: &[CurrencyAssign]) {
+        self.currency_assign.set_items(val);
+    }
+
+    /// Builder function that sets the list of [CurrencyAssign] items.
+    pub fn with_currency_assign(mut self, val: &[CurrencyAssign]) -> Self {
+        self.set_currency_assign(val);
+        self
+    }
+
+    /// Gets the length of the [CurrencyAssignResponse] metadata.
+    pub const fn meta_len() -> usize {
+        ResponseCode::len()
+    }
+
+    /// Gets the full length of the [CurrencyAssignResponse].
+    pub fn len(&self) -> usize {
+        Self::meta_len() + self.currency_assign.len()
+    }
+
+    /// Gets whether the [CurrencyAssignResponse] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.code.is_empty() && self.currency_assign.is_empty()
+    }
+
+    /// Converts a [CurrencyAssignResponse] into a byte buffer.
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<()> {
+        let len = self.len();
+        let buf_len = buf.len();
+
+        match buf_len {
+            bl if bl < len => Err(Error::InvalidResponseLen((buf_len, len))),
+            _ => {
+                buf.iter_mut()
+                    .take(len)
+                    .zip(
+                        [self.code.into()]
+                            .into_iter()
+                            .chain(self.currency_assign.iter_bytes()),
+                    )
+                    .for_each(|(dst, src)| *dst = src);
+
+                Ok(())
+            }
+        }
+    }
+
+    /// Converts a byte buffer into a [CurrencyAssignResponse].
+    pub fn from_bytes(buf: &[u8]) -> Result<Self> {
+        let meta_len = Self::meta_len();
+        let buf_len = buf.len();
+
+        match buf_len {
+            bl if bl < meta_len => Err(Error::InvalidResponseLen((buf_len, meta_len))),
+            bl if bl == meta_len => Ok(Self {
+                code: buf[0].try_into()?,
+                currency_assign: CurrencyAssignList::new(),
+            }),
+            _ => Ok(Self {
+                code: buf[0].try_into()?,
+                currency_assign: buf[1..].as_ref().try_into()?,
+            }),
+        }
+    }
+}
+
+impl Default for CurrencyAssignResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&Response> for CurrencyAssignResponse {
+    type Error = Error;
+
+    fn try_from(val: &Response) -> Result<Self> {
+        let meta_len = Self::meta_len();
+
+        match val.len() {
+            res_len if res_len < meta_len => Err(Error::InvalidResponseLen((res_len, meta_len))),
+            _ => Ok(Self {
+                code: val.code,
+                currency_assign: CurrencyAssignList::try_from(val.additional())?,
+            }),
+        }
+    }
+}
+
+impl TryFrom<Response> for CurrencyAssignResponse {
+    type Error = Error;
+
+    fn try_from(val: Response) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl TryFrom<&Message> for CurrencyAssignResponse {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        Response::try_from(val)?.try_into()
+    }
+}
+
+impl TryFrom<Message> for CurrencyAssignResponse {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        Response::try_from(val)?.try_into()
+    }
+}
+
+impl From<&CurrencyAssignResponse> for Response {
+    fn from(val: &CurrencyAssignResponse) -> Self {
+        Self {
+            code: val.code,
+            additional: val.currency_assign.iter_bytes().collect(),
+        }
+    }
+}
+
+impl From<CurrencyAssignResponse> for Response {
+    fn from(val: CurrencyAssignResponse) -> Self {
+        (&val).into()
+    }
+}
+
+impl fmt::Display for CurrencyAssignResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""code":{}, "#, self.code)?;
+        write!(f, r#""currency_assign": {}"#, self.currency_assign)?;
+        write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Currency, CurrencyCode, Denomination};
+
+    #[test]
+    fn test_currency_assign_response() {
+        let raw = [
+            ResponseCode::Ack as u8,
+            0,
+            b'J',
+            b'P',
+            b'Y',
+            1,
+            0,
+            1,
+            b'J',
+            b'P',
+            b'Y',
+            5,
+            0,
+        ];
+
+        let exp_currency_assign: Vec<CurrencyAssign> = [1u64, 5u64]
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                CurrencyAssign::new()
+                    .with_bit_number(i as u8)
+                    .with_currency(
+                        Currency::new()
+                            .with_code(CurrencyCode::JPY)
+                            .with_denomination(Denomination::from_value(v)),
+                    )
+            })
+            .collect();
+
+        let exp = CurrencyAssignResponse::new()
+            .with_code(ResponseCode::Ack)
+            .with_currency_assign(exp_currency_assign.as_ref());
+
+        let res = Response::new()
+            .with_code(ResponseCode::Ack)
+            .with_additional(&raw[1..]);
+
+        let mut out = [0u8; 13];
+
+        assert_eq!(
+            CurrencyAssignResponse::from_bytes(raw.as_ref()).as_ref(),
+            Ok(&exp)
+        );
+        assert_eq!(CurrencyAssignResponse::try_from(&res).as_ref(), Ok(&exp));
+        assert_eq!(Response::from(&exp), res);
+
+        assert!(exp.to_bytes(out.as_mut()).is_ok());
+
+        assert_eq!(out, raw);
+    }
+
+    #[test]
+    fn test_currency_assign_response_invalid() {
+        let raw = [ResponseCode::Ack as u8, 0, 0, 0, 0, 0, 0];
+        let exp = CurrencyAssignResponse::new()
+            .with_code(ResponseCode::Ack)
+            .with_currency_assign(&[CurrencyAssign::new()]);
+        let mut out = [0u8; 7];
+
+        assert!(CurrencyAssignResponse::from_bytes(raw[..2].as_ref()).is_err());
+        assert!(
+            CurrencyAssignResponse::from_bytes([ResponseCode::Reserved as u8, 0].as_ref()).is_err()
+        );
+        assert!(exp.to_bytes(out[..1].as_mut()).is_err());
+        assert!(exp.to_bytes(&mut []).is_err());
+        assert!(CurrencyAssignResponse::try_from(Response::new().with_additional(&[])).is_err());
+        assert!(CurrencyAssignResponse::try_from(
+            Response::new()
+                .with_code(ResponseCode::Ack)
+                .with_additional(&[])
+        )
+        .is_err());
+    }
+}

--- a/src/message/response/currency_assign_response/currency_assign.rs
+++ b/src/message/response/currency_assign_response/currency_assign.rs
@@ -1,0 +1,233 @@
+use std::fmt;
+
+use crate::{Currency, Error, Result};
+
+pub const CURRENCY_ASSIGN_LEN: usize = 6;
+
+/// Represents a currency-to-bit assignment for
+/// [CurrencyAssignResponse](crate::CurrencyAssignResponse) messages.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CurrencyAssign {
+    bit: u8,
+    currency: Currency,
+}
+
+impl CurrencyAssign {
+    /// Creates a new [CurrencyAssign].
+    pub const fn new() -> Self {
+        Self {
+            bit: 0,
+            currency: Currency::new(),
+        }
+    }
+
+    /// Gets the bit number of the [CurrencyAssign].
+    pub const fn bit_number(&self) -> u8 {
+        self.bit
+    }
+
+    /// Sets the bit number of the [CurrencyAssign].
+    pub fn set_bit_number(&mut self, val: u8) {
+        self.bit = val;
+    }
+
+    /// Builder function that sets the bit number of the [CurrencyAssign].
+    pub fn with_bit_number(mut self, val: u8) -> Self {
+        self.set_bit_number(val);
+        self
+    }
+
+    /// Gets the currency of the [CurrencyAssign].
+    pub const fn currency(&self) -> Currency {
+        self.currency
+    }
+
+    /// Sets the currency of the [CurrencyAssign].
+    pub fn set_currency(&mut self, val: Currency) {
+        self.currency = val;
+    }
+
+    /// Builder function that sets the currency of the [CurrencyAssign].
+    pub fn with_currency(mut self, val: Currency) -> Self {
+        self.set_currency(val);
+        self
+    }
+
+    /// Converts a byte buffer into a [CurrencyAssign].
+    pub fn from_bytes(buf: &[u8]) -> Result<Self> {
+        match buf.len() {
+            len if len >= CURRENCY_ASSIGN_LEN => Ok(Self {
+                bit: buf[0],
+                currency: Currency::from_bytes(&buf[1..CURRENCY_ASSIGN_LEN])?,
+            }),
+            len => Err(Error::InvalidCurrencyAssignLen((len, CURRENCY_ASSIGN_LEN))),
+        }
+    }
+
+    /// Writes a [CurrencyAssign] into a byte buffer.
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<()> {
+        match buf.len() {
+            len if len >= CURRENCY_ASSIGN_LEN => {
+                buf[0] = self.bit;
+                self.currency.to_bytes(&mut buf[1..CURRENCY_ASSIGN_LEN])?;
+                Ok(())
+            }
+            len => Err(Error::InvalidCurrencyAssignLen((len, CURRENCY_ASSIGN_LEN))),
+        }
+    }
+
+    /// Converts the [CurrencyAssign] into a byte array.
+    pub fn into_bytes(&self) -> [u8; CURRENCY_ASSIGN_LEN] {
+        let mut buf = [0u8; CURRENCY_ASSIGN_LEN];
+        self.to_bytes(buf.as_mut()).ok();
+        buf
+    }
+}
+
+impl Default for CurrencyAssign {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<&CurrencyAssign> for [u8; CURRENCY_ASSIGN_LEN] {
+    fn from(val: &CurrencyAssign) -> Self {
+        val.into_bytes()
+    }
+}
+
+impl From<CurrencyAssign> for [u8; CURRENCY_ASSIGN_LEN] {
+    fn from(val: CurrencyAssign) -> Self {
+        (&val).into()
+    }
+}
+
+impl TryFrom<&[u8]> for CurrencyAssign {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        Self::from_bytes(val)
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for CurrencyAssign {
+    type Error = Error;
+
+    fn try_from(val: &[u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+impl<const N: usize> TryFrom<[u8; N]> for CurrencyAssign {
+    type Error = Error;
+
+    fn try_from(val: [u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+
+impl fmt::Display for CurrencyAssign {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""bit_number": {}, "#, self.bit)?;
+        write!(f, r#""currency": {}"#, self.currency)?;
+        write!(f, "}}")
+    }
+}
+
+/// Represents a list of [CurrencyAsssign].
+#[repr(C)]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CurrencyAssignList(Vec<CurrencyAssign>);
+
+impl CurrencyAssignList {
+    /// Creates a new [CurrencyAssignList].
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Gets a reference to the list of [CurrencyAssign] items.
+    pub fn items(&self) -> &[CurrencyAssign] {
+        self.0.as_ref()
+    }
+
+    /// Sets a reference to the list of [CurrencyAssign] items.
+    pub fn set_items(&mut self, items: &[CurrencyAssign]) {
+        self.0 = items.into();
+    }
+
+    /// Builder function that sets a reference to the list of [CurrencyAssign] items.
+    pub fn with_items(mut self, items: &[CurrencyAssign]) -> Self {
+        self.set_items(items);
+        self
+    }
+
+    /// Gets an iterator over the list of [CurrencyAssign] items.
+    pub fn iter(&self) -> impl Iterator<Item = &CurrencyAssign> {
+        self.0.iter()
+    }
+
+    /// Gets a mutable iterator over the list of [CurrencyAssign] items.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut CurrencyAssign> {
+        self.0.iter_mut()
+    }
+
+    /// Gets the byte length of the [CurrencyAssignList].
+    pub fn len(&self) -> usize {
+        self.0.len().saturating_mul(CURRENCY_ASSIGN_LEN)
+    }
+
+    /// Gets whether the [CurrencyAssignList] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Pushes a [CurrencyAssign] item onto the [CurrencyAssignList].
+    pub fn push(&mut self, item: CurrencyAssign) {
+        self.0.push(item);
+    }
+
+    /// Pops a [CurrencyAssign] item onto the [CurrencyAssignList].
+    pub fn pop(&mut self) -> Option<CurrencyAssign> {
+        self.0.pop()
+    }
+
+    /// Gets an iterator over the [CurrencyAssignList] converted to bytes.
+    pub fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
+        self.0.iter().flat_map(|c| c.into_bytes().into_iter())
+    }
+}
+
+impl Default for CurrencyAssignList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&[u8]> for CurrencyAssignList {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        match val.len() {
+            len if len >= CURRENCY_ASSIGN_LEN && len % CURRENCY_ASSIGN_LEN == 0 => Ok(Self(
+                val.chunks_exact(CURRENCY_ASSIGN_LEN)
+                    .filter_map(|c| CurrencyAssign::try_from(c).ok())
+                    .collect(),
+            )),
+            len => Err(Error::InvalidCurrencyAssignLen((len, CURRENCY_ASSIGN_LEN))),
+        }
+    }
+}
+
+impl fmt::Display for CurrencyAssignList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        for (i, ca) in self.0.iter().enumerate() {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{ca}")?;
+        }
+        write!(f, "]")
+    }
+}

--- a/tests/e2e_tests/usb.rs
+++ b/tests/e2e_tests/usb.rs
@@ -284,3 +284,50 @@ fn test_direction_disable() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_currency_assign() -> Result<()> {
+    let _lock = common::init()?;
+
+    let usb = Arc::new(Mutex::new(jcm::usb::UsbDeviceHandle::find_usb()?));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let (event_send, event_recv) = crossbeam::channel::unbounded();
+    let (response_send, response_recv) = crossbeam::channel::unbounded();
+    let (event_res_send, event_res_recv) = crossbeam::channel::unbounded();
+
+    jcm::usb::poll_device_message(
+        Arc::clone(&usb),
+        Arc::clone(&stop),
+        event_send,
+        event_res_recv,
+        response_send,
+    )?;
+
+    jcm::usb::wait_for_power_up(&event_recv, &event_res_send).ok();
+
+    ack_event_responder(Arc::clone(&stop), event_recv, event_res_send)?;
+
+    let req: jcm::Message = jcm::MessageData::from(jcm::CurrencyAssignRequest::new())
+        .with_uid(1)
+        .into();
+    let res: jcm::CurrencyAssignResponse =
+        jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?.try_into()?;
+
+    log::info!("Currency assign response: {res}");
+
+    common_startup(&usb, &response_recv)?;
+
+    thread::sleep(time::Duration::from_millis(5000));
+
+    let req: jcm::Message = jcm::MessageData::from(jcm::IdleRequest::new())
+        .with_uid(1)
+        .into();
+    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+
+    log::info!("Idle response: {res}");
+
+    stop.store(true, Ordering::SeqCst);
+
+    Ok(())
+}


### PR DESCRIPTION
Adds `CurrencyAssignRequest` and `CurrencyAssignResponse` types to represent requests and responses for the bit-to-currency mapping from the device.

The `CurrencyAssign` type contains the bit-to-currency mapping used in `DisableDenominationRequest` messages.