### PR TITLE
response: add denomination disable type

### DIFF
--- a/src/message/request/denomination_disable_request/denomination_disable.rs
+++ b/src/message/request/denomination_disable_request/denomination_disable.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::{Error, Result};
 
 /// Represents a set of denominations to disable on the device.
@@ -137,7 +139,7 @@ impl TryFrom<&[u8]> for DenominationDisable {
     fn try_from(val: &[u8]) -> Result<Self> {
         match val.len() {
             2 => Ok(Self::from_bytes(val)),
-            len => Err(Error::InvalidRequestLen((len, Self::len()))),
+            len => Err(Error::InvalidDenominationLen((len, Self::len()))),
         }
     }
 }
@@ -151,5 +153,149 @@ impl From<DenominationDisable> for [u8; 2] {
 impl From<&DenominationDisable> for [u8; 2] {
     fn from(val: &DenominationDisable) -> Self {
         val.to_bytes()
+    }
+}
+
+impl fmt::Display for DenominationDisable {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#"{{"denomination_disable": "{:#018b}"}}"#, self.0)
+    }
+}
+
+/// Represents a list of [DenominationDisable] items.
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DenominationDisableList(Vec<DenominationDisable>);
+
+impl DenominationDisableList {
+    /// Creates a new [DenominationDisableList].
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Gets a reference to the list of [DenominationDisable] items.
+    pub fn items(&self) -> &[DenominationDisable] {
+        self.0.as_ref()
+    }
+
+    /// Gets the byte length of the [DenominationDisableList].
+    pub fn len(&self) -> usize {
+        self.0.len().saturating_mul(DenominationDisable::len())
+    }
+
+    /// Gets whether the [DenominationDisableList] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Pushes a [DenominationDisable] item onto the [DenominationDisableList].
+    pub fn push(&mut self, val: DenominationDisable) {
+        self.0.push(val);
+    }
+
+    /// Appends [DenominationDisable] items from a [`Vec<DenominationDisable>`].
+    ///
+    /// Empties the source vector.
+    pub fn append(&mut self, oth: &mut Vec<DenominationDisable>) {
+        self.0.append(oth);
+    }
+
+    /// Gets an iterator over the list of [DenominationDisable] items.
+    pub fn iter(&self) -> impl Iterator<Item = &DenominationDisable> {
+        self.0.iter()
+    }
+
+    /// Gets a mutable iterator over the list of [DenominationDisable] items.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut DenominationDisable> {
+        self.0.iter_mut()
+    }
+
+    /// Infallible conversion of a byte buffer into a [DenominationDisableList].
+    pub fn from_bytes(buf: &[u8]) -> Self {
+        Self(
+            buf.chunks(DenominationDisable::len())
+                .map(DenominationDisable::from_bytes)
+                .collect(),
+        )
+    }
+
+    /// Gets an iterator over the list of [DenominationDisable] bytes.
+    pub fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
+        self.0.iter().flat_map(|d| d.to_bytes().into_iter())
+    }
+
+    /// Gets an iterator over the list of [DenominationDisable] bytes.
+    pub fn into_iter_bytes(self) -> impl Iterator<Item = u8> {
+        self.0.into_iter().flat_map(|d| d.to_bytes().into_iter())
+    }
+
+    /// Converts the [DenominationDisableList] into a byte vector.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.iter_bytes().collect()
+    }
+
+    /// Converts the [DenominationDisableList] into a byte vector.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.into_iter_bytes().collect()
+    }
+}
+
+impl IntoIterator for DenominationDisableList {
+    type Item = DenominationDisable;
+    type IntoIter = std::vec::IntoIter<DenominationDisable>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Default for DenominationDisableList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<DenominationDisableList> for Vec<u8> {
+    fn from(val: DenominationDisableList) -> Self {
+        val.into_bytes()
+    }
+}
+
+impl From<&DenominationDisableList> for Vec<u8> {
+    fn from(val: &DenominationDisableList) -> Self {
+        val.to_bytes()
+    }
+}
+
+impl From<&[DenominationDisable]> for DenominationDisableList {
+    fn from(val: &[DenominationDisable]) -> Self {
+        Self(val.into())
+    }
+}
+
+impl TryFrom<&[u8]> for DenominationDisableList {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        match val.len() {
+            len if len > 0 && len % DenominationDisable::len() == 0 => Ok(Self::from_bytes(val)),
+            len => Err(Error::InvalidDenominationLen((
+                len,
+                DenominationDisable::len(),
+            ))),
+        }
+    }
+}
+
+impl fmt::Display for DenominationDisableList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        for (i, denom) in self.0.iter().enumerate() {
+            if i != 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{denom}")?;
+        }
+        write!(f, "]")
     }
 }

--- a/src/message/response.rs
+++ b/src/message/response.rs
@@ -3,12 +3,14 @@ use std::fmt;
 use crate::{Error, Message, Result};
 
 mod currency_assign_response;
+mod denomination_disable_response;
 mod response_code;
 mod status_response;
 mod uid_response;
 mod version_response;
 
 pub use currency_assign_response::*;
+pub use denomination_disable_response::*;
 pub use response_code::*;
 pub use status_response::*;
 pub use uid_response::*;

--- a/src/message/response/denomination_disable_response.rs
+++ b/src/message/response/denomination_disable_response.rs
@@ -1,0 +1,218 @@
+use std::fmt;
+
+use crate::{
+    DenominationDisable, DenominationDisableList, Error, Message, RequestCode, Response,
+    ResponseCode, Result,
+};
+
+/// Represents the [Response] to a [DenominationDisableRequest](crate::DenominationDisableRequest).
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DenominationDisableResponse {
+    code: ResponseCode,
+    denoms: DenominationDisableList,
+}
+
+impl DenominationDisableResponse {
+    /// Creates a new [DenominationDisableResponse].
+    pub const fn new() -> Self {
+        Self {
+            code: ResponseCode::new(),
+            denoms: DenominationDisableList::new(),
+        }
+    }
+
+    /// Gets the [ResponseCode] for the [DenominationDisableResponse].
+    pub const fn code(&self) -> ResponseCode {
+        self.code
+    }
+
+    /// Sets the [ResponseCode] for the [DenominationDisableResponse].
+    pub fn set_code(&mut self, code: ResponseCode) {
+        self.code = code;
+    }
+
+    /// Builder function that sets the [ResponseCode] for the [DenominationDisableResponse].
+    pub fn with_code(mut self, code: ResponseCode) -> Self {
+        self.set_code(code);
+        self
+    }
+
+    /// Gets the list of [DenominationDisable] items for the [DenominationDisableResponse].
+    pub fn denominations(&self) -> &[DenominationDisable] {
+        self.denoms.items()
+    }
+
+    /// Sets the list of [DenominationDisable] items for the [DenominationDisableResponse].
+    pub fn set_denominations(&mut self, denoms: &[DenominationDisable]) {
+        self.denoms = denoms.into();
+    }
+
+    /// Builder function that sets the list of [DenominationDisable] items for the [DenominationDisableResponse].
+    pub fn with_denominations(mut self, denoms: &[DenominationDisable]) -> Self {
+        self.set_denominations(denoms);
+        self
+    }
+
+    /// Gets the metadata length of the [DenominatinoDisableResponse].
+    pub const fn meta_len() -> usize {
+        ResponseCode::len()
+    }
+
+    /// Gets the length of the [DenominationDisableResponse].
+    pub fn len(&self) -> usize {
+        ResponseCode::len().saturating_add(self.denoms.len())
+    }
+
+    /// Gets whether the [DenominationDisableResponse] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.code.is_empty() && self.denoms.is_empty()
+    }
+
+    /// Gets an iterator over [DenominationDisableResponse] bytes.
+    pub fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
+        [u8::from(self.code)]
+            .into_iter()
+            .chain(self.denoms.iter_bytes())
+    }
+
+    /// Gets an iterator over [DenominationDisableResponse] bytes.
+    pub fn into_iter_bytes(self) -> impl Iterator<Item = u8> {
+        [u8::from(self.code)]
+            .into_iter()
+            .chain(self.denoms.into_iter_bytes())
+    }
+
+    /// Converts a [DenominationDisableResponse] into a byte vector.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.iter_bytes().collect()
+    }
+
+    /// Converts a [DenominationDisableResponse] into a byte vector.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.into_iter_bytes().collect()
+    }
+
+    /// Converts a byte buffer into a [DenominationDisableResponse].
+    pub fn from_bytes(buf: &[u8]) -> Result<Self> {
+        let len = Self::meta_len();
+        let buf_len = buf.len();
+
+        let denoms = DenominationDisableList::from_bytes(buf.get(1..).unwrap_or_default());
+
+        if buf_len < len {
+            Err(Error::InvalidResponseLen((buf_len, len)))
+        } else {
+            Ok(Self {
+                code: buf[0].try_into()?,
+                denoms,
+            })
+        }
+    }
+}
+
+impl Default for DenominationDisableResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<&Response> for DenominationDisableResponse {
+    fn from(val: &Response) -> Self {
+        Self {
+            code: val.code(),
+            denoms: DenominationDisableList::from_bytes(val.additional()),
+        }
+    }
+}
+
+impl From<Response> for DenominationDisableResponse {
+    fn from(val: Response) -> Self {
+        (&val).into()
+    }
+}
+
+impl From<DenominationDisableResponse> for Response {
+    fn from(val: DenominationDisableResponse) -> Self {
+        Self {
+            code: val.code,
+            additional: val.denoms.into_bytes(),
+        }
+    }
+}
+
+impl From<&DenominationDisableResponse> for Response {
+    fn from(val: &DenominationDisableResponse) -> Self {
+        Self {
+            code: val.code,
+            additional: val.denoms.to_bytes(),
+        }
+    }
+}
+
+impl TryFrom<Message> for DenominationDisableResponse {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl TryFrom<&Message> for DenominationDisableResponse {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        match val.data.message_code().request_code()? {
+            RequestCode::DenominationDisable => Ok(Response::try_from(val)?.into()),
+            code => Err(Error::InvalidRequestCode(code.into())),
+        }
+    }
+}
+
+impl fmt::Display for DenominationDisableResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""code":{}, "#, self.code)?;
+        write!(f, r#""denominations":{}"#, self.denoms)?;
+        write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_denomination_disable_response() {
+        let raw = [ResponseCode::Ack as u8, 0, 0];
+        let exp = DenominationDisableResponse::new()
+            .with_code(ResponseCode::Ack)
+            .with_denominations(&[DenominationDisable::new()]);
+        let res = Response::new()
+            .with_code(ResponseCode::Ack)
+            .with_additional(&[0, 0]);
+
+        assert_eq!(
+            DenominationDisableResponse::from_bytes(raw.as_ref()).as_ref(),
+            Ok(&exp)
+        );
+        assert_eq!(
+            DenominationDisableResponse::try_from(&res).as_ref(),
+            Ok(&exp)
+        );
+        assert_eq!(Response::from(&exp), res);
+
+        let out = exp.into_bytes();
+
+        assert_eq!(out, raw);
+    }
+
+    #[test]
+    fn test_denomination_disable_response_invalid() {
+        assert!(DenominationDisableResponse::from_bytes(&[]).is_err());
+        assert!(DenominationDisableResponse::from_bytes(
+            [ResponseCode::Reserved as u8, 0].as_ref()
+        )
+        .is_err());
+    }
+}

--- a/tests/e2e_tests/usb.rs
+++ b/tests/e2e_tests/usb.rs
@@ -197,15 +197,11 @@ fn test_denomination_disable() -> Result<()> {
 
     log::info!("Status response: {res}");
 
-    let req: jcm::Message = jcm::MessageData::from(jcm::ResetRequest::new())
-        .with_uid(1)
-        .into();
-    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
-
     let req: jcm::Message = jcm::MessageData::from(jcm::DenominationDisableRequest::new())
         .with_uid(1)
         .into();
-    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let res: jcm::DenominationDisableResponse =
+        jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?.try_into()?;
 
     log::info!("Denomination disable (get) response: {res}");
 
@@ -214,14 +210,16 @@ fn test_denomination_disable() -> Result<()> {
         .with_denominations(&[jcm::DenominationDisable::new().with_disable(1)])?;
 
     let req: jcm::Message = jcm::MessageData::from(dir_req).with_uid(1).into();
-    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let res: jcm::DenominationDisableResponse =
+        jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?.try_into()?;
 
     log::info!("Denomination disable (set) response: {res}");
 
     let req: jcm::Message = jcm::MessageData::from(jcm::DenominationDisableRequest::new())
         .with_uid(1)
         .into();
-    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let res: jcm::DenominationDisableResponse =
+        jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?.try_into()?;
 
     log::info!("Denomination disable (get) response: {res}");
 


### PR DESCRIPTION
Adds the `DenominationDisableResponse` type to represent responses to `DenominationDisableRequest` messages.

Adds the `DenominationDisableList` type to represent a list of `DenominationDisable` items.