### PR TITLE
response: add direction disable type

### DIFF
--- a/src/message/request/direction_disable_request/direction_inhibit.rs
+++ b/src/message/request/direction_disable_request/direction_inhibit.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 /// Represents variants for inhibiting a denomination direction.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -65,5 +67,26 @@ impl From<DirectionInhibit> for bool {
 impl From<&DirectionInhibit> for bool {
     fn from(val: &DirectionInhibit) -> Self {
         (*val).into()
+    }
+}
+
+impl From<DirectionInhibit> for &'static str {
+    fn from(val: DirectionInhibit) -> Self {
+        match val {
+            DirectionInhibit::Accept => "accept",
+            DirectionInhibit::Inhibit => "inhibit",
+        }
+    }
+}
+
+impl From<&DirectionInhibit> for &'static str {
+    fn from(val: &DirectionInhibit) -> Self {
+        (*val).into()
+    }
+}
+
+impl fmt::Display for DirectionInhibit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, <&str>::from(self))
     }
 }

--- a/src/message/request/direction_disable_request/inhibit_direction.rs
+++ b/src/message/request/direction_disable_request/inhibit_direction.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use crate::DirectionInhibit;
 
 const FACE_DOWN_RIGHT_SIDE_SHIFT: u8 = 3;
@@ -108,6 +110,39 @@ impl InhibitDirection {
     pub fn with_face_up_left_side(mut self, val: DirectionInhibit) -> Self {
         self.set_face_up_left_side(val);
         self
+    }
+
+    /// Gets the length of the [InhibitDirection].
+    pub const fn len() -> usize {
+        std::mem::size_of::<u8>()
+    }
+
+    /// Gets whether the [InhibitDirection] is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl fmt::Display for InhibitDirection {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(
+            f,
+            r#""face_down_right_side": {}, "#,
+            self.face_down_right_side()
+        )?;
+        write!(
+            f,
+            r#""face_down_left_side": {}, "#,
+            self.face_down_left_side()
+        )?;
+        write!(
+            f,
+            r#""face_up_right_side": {}, "#,
+            self.face_up_right_side()
+        )?;
+        write!(f, r#""face_up_left_side": {}"#, self.face_up_left_side())?;
+        write!(f, "}}")
     }
 }
 

--- a/src/message/response.rs
+++ b/src/message/response.rs
@@ -4,6 +4,7 @@ use crate::{Error, Message, Result};
 
 mod currency_assign_response;
 mod denomination_disable_response;
+mod direction_disable_response;
 mod response_code;
 mod status_response;
 mod uid_response;
@@ -11,6 +12,7 @@ mod version_response;
 
 pub use currency_assign_response::*;
 pub use denomination_disable_response::*;
+pub use direction_disable_response::*;
 pub use response_code::*;
 pub use status_response::*;
 pub use uid_response::*;

--- a/src/message/response/denomination_disable_response.rs
+++ b/src/message/response/denomination_disable_response.rs
@@ -196,10 +196,7 @@ mod tests {
             DenominationDisableResponse::from_bytes(raw.as_ref()).as_ref(),
             Ok(&exp)
         );
-        assert_eq!(
-            DenominationDisableResponse::try_from(&res).as_ref(),
-            Ok(&exp)
-        );
+        assert_eq!(&DenominationDisableResponse::from(&res), &exp);
         assert_eq!(Response::from(&exp), res);
 
         let out = exp.into_bytes();

--- a/src/message/response/direction_disable_response.rs
+++ b/src/message/response/direction_disable_response.rs
@@ -1,0 +1,201 @@
+use std::fmt;
+
+use crate::{Error, InhibitDirection, Message, RequestCode, Response, ResponseCode, Result};
+
+/// Represents the [Response] to a [DirectionDisableRequest](crate::DirectionDisableRequest).
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DirectionDisableResponse {
+    code: ResponseCode,
+    dirs: InhibitDirection,
+}
+
+impl DirectionDisableResponse {
+    /// Creates a new [DirectionDisableResponse].
+    pub const fn new() -> Self {
+        Self {
+            code: ResponseCode::new(),
+            dirs: InhibitDirection::new(),
+        }
+    }
+
+    /// Gets the [ResponseCode] for the [DirectionDisableResponse].
+    pub const fn code(&self) -> ResponseCode {
+        self.code
+    }
+
+    /// Sets the [ResponseCode] for the [DirectionDisableResponse].
+    pub fn set_code(&mut self, code: ResponseCode) {
+        self.code = code;
+    }
+
+    /// Builder function that sets the [ResponseCode] for the [DirectionDisableResponse].
+    pub fn with_code(mut self, code: ResponseCode) -> Self {
+        self.set_code(code);
+        self
+    }
+
+    /// Gets the [InhibitDirection] for the [InhibitDirectionResponse].
+    pub fn directions(&self) -> InhibitDirection {
+        self.dirs
+    }
+
+    /// Sets the [InhibitDirection] for the [InhibitDirectionResponse].
+    pub fn set_directions(&mut self, dirs: InhibitDirection) {
+        self.dirs = dirs;
+    }
+
+    /// Builder function that sets the [InhibitDirection] for the [InhibitDirectionResponse].
+    pub fn with_directions(mut self, dirs: InhibitDirection) -> Self {
+        self.set_directions(dirs);
+        self
+    }
+
+    /// Gets the length of the [DirectionDisableResponse].
+    pub const fn len() -> usize {
+        ResponseCode::len() + InhibitDirection::len()
+    }
+
+    /// Gets whether the [DirectionDisableResponse] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.code.is_empty() && self.dirs.is_empty()
+    }
+
+    /// Gets an iterator over [DirectionDisableResponse] bytes.
+    pub fn iter_bytes(&self) -> impl Iterator<Item = u8> + '_ {
+        [self.code.into(), self.dirs.into()].into_iter()
+    }
+
+    /// Gets an iterator over [DirectionDisableResponse] bytes.
+    pub fn into_iter_bytes(self) -> impl Iterator<Item = u8> {
+        [self.code.into(), self.dirs.into()].into_iter()
+    }
+
+    /// Converts a [DirectionDisableResponse] into a byte vector.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.iter_bytes().collect()
+    }
+
+    /// Converts a [DirectionDisableResponse] into a byte vector.
+    pub fn into_bytes(self) -> Vec<u8> {
+        self.into_iter_bytes().collect()
+    }
+
+    /// Converts a byte buffer into a [DirectionDisableResponse].
+    pub fn from_bytes(buf: &[u8]) -> Result<Self> {
+        let len = Self::len();
+        let buf_len = buf.len();
+
+        if buf_len < len {
+            Err(Error::InvalidResponseLen((buf_len, len)))
+        } else {
+            Ok(Self {
+                code: buf[0].try_into()?,
+                dirs: buf.get(1).copied().unwrap_or(0).into(),
+            })
+        }
+    }
+}
+
+impl Default for DirectionDisableResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<&Response> for DirectionDisableResponse {
+    fn from(val: &Response) -> Self {
+        Self {
+            code: val.code(),
+            dirs: val.additional().first().copied().unwrap_or(0).into(),
+        }
+    }
+}
+
+impl From<Response> for DirectionDisableResponse {
+    fn from(val: Response) -> Self {
+        (&val).into()
+    }
+}
+
+impl From<DirectionDisableResponse> for Response {
+    fn from(val: DirectionDisableResponse) -> Self {
+        Self {
+            code: val.code,
+            additional: [val.dirs.bits()].into(),
+        }
+    }
+}
+
+impl From<&DirectionDisableResponse> for Response {
+    fn from(val: &DirectionDisableResponse) -> Self {
+        Self {
+            code: val.code,
+            additional: [val.dirs.bits()].into(),
+        }
+    }
+}
+
+impl TryFrom<Message> for DirectionDisableResponse {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl TryFrom<&Message> for DirectionDisableResponse {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        match val.data.message_code().request_code()? {
+            RequestCode::DirectionDisable => Ok(Response::try_from(val)?.into()),
+            code => Err(Error::InvalidRequestCode(code.into())),
+        }
+    }
+}
+
+impl fmt::Display for DirectionDisableResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""code":{}, "#, self.code)?;
+        write!(f, r#""directions":{}"#, self.dirs)?;
+        write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_direction_disable_response() {
+        let raw = [ResponseCode::Ack as u8, 0];
+        let exp = DirectionDisableResponse::new()
+            .with_code(ResponseCode::Ack)
+            .with_directions(InhibitDirection::new());
+        let res = Response::new()
+            .with_code(ResponseCode::Ack)
+            .with_additional(&[0]);
+
+        assert_eq!(
+            DirectionDisableResponse::from_bytes(raw.as_ref()).as_ref(),
+            Ok(&exp)
+        );
+        assert_eq!(&DirectionDisableResponse::from(&res), &exp);
+        assert_eq!(Response::from(&exp), res);
+
+        let out = exp.into_bytes();
+
+        assert_eq!(out, raw);
+    }
+
+    #[test]
+    fn test_direction_disable_response_invalid() {
+        assert!(DirectionDisableResponse::from_bytes(&[]).is_err());
+        assert!(
+            DirectionDisableResponse::from_bytes([ResponseCode::Reserved as u8, 0].as_ref())
+                .is_err()
+        );
+    }
+}

--- a/tests/e2e_tests/usb.rs
+++ b/tests/e2e_tests/usb.rs
@@ -290,7 +290,8 @@ fn test_direction_disable() -> Result<()> {
     let req: jcm::Message = jcm::MessageData::from(jcm::DirectionDisableRequest::new())
         .with_uid(1)
         .into();
-    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let res: jcm::DirectionDisableResponse =
+        jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?.try_into()?;
 
     log::info!("Direction disable (get) response: {res}");
 
@@ -299,14 +300,16 @@ fn test_direction_disable() -> Result<()> {
         .with_direction(jcm::InhibitDirection::create(0xf));
 
     let req: jcm::Message = jcm::MessageData::from(dir_req).with_uid(1).into();
-    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let res: jcm::DirectionDisableResponse =
+        jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?.try_into()?;
 
     log::info!("Direction disable (set) response: {res}");
 
     let req: jcm::Message = jcm::MessageData::from(jcm::DirectionDisableRequest::new())
         .with_uid(1)
         .into();
-    let res = jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?;
+    let res: jcm::DirectionDisableResponse =
+        jcm::usb::poll_request(Arc::clone(&usb), &req, &response_recv, 3)?.try_into()?;
 
     log::info!("Direction disable (get) response: {res}");
 


### PR DESCRIPTION
Adds the `DirectionDisableResponse` type to represent responses to `DirectionDisableRequest` messages.