### PR TITLE
message: add cash box size types

### DIFF
--- a/src/cash_box_size.rs
+++ b/src/cash_box_size.rs
@@ -1,0 +1,190 @@
+use std::{ffi, fmt};
+
+use crate::{Error, Result};
+
+/// Represents a `Cash Box Size`.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CashBoxSize(u64);
+
+impl CashBoxSize {
+    /// Creates a new [CashBoxSize].
+    pub const fn new() -> Self {
+        Self(0)
+    }
+
+    /// Creates a new [CashBoxSize] from the provided parameter.
+    pub const fn create(val: u64) -> Self {
+        Self(val)
+    }
+
+    /// Gets the cash box size.
+    pub const fn size(&self) -> u64 {
+        self.0
+    }
+
+    /// Converts the [CashBoxSize] into a nul-terminated [`String`].
+    pub fn into_string_with_nul(self) -> String {
+        format!("{self}\0")
+    }
+
+    /// Gets the string length of the [CashBoxSize].
+    pub const fn len(&self) -> usize {
+        (self.0.ilog10() + 2) as usize
+    }
+
+    /// Gets whether the [CashBoxSize] is empty.
+    pub const fn is_empty(&self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl Default for CashBoxSize {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IntoIterator for CashBoxSize {
+    type Item = u8;
+    type IntoIter = <Vec<u8> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        <Vec<u8>>::from(self).into_iter()
+    }
+}
+
+impl TryFrom<&[u8]> for CashBoxSize {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        ffi::CStr::from_bytes_until_nul(val)?.try_into()
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for CashBoxSize {
+    type Error = Error;
+
+    fn try_from(val: &[u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+
+impl<const N: usize> TryFrom<[u8; N]> for CashBoxSize {
+    type Error = Error;
+
+    fn try_from(val: [u8; N]) -> Result<Self> {
+        val.as_ref().try_into()
+    }
+}
+
+impl TryFrom<&ffi::CStr> for CashBoxSize {
+    type Error = Error;
+
+    fn try_from(val: &ffi::CStr) -> Result<Self> {
+        Ok(Self(
+            val.to_str()?
+                .parse::<u64>()
+                .map_err(|_| Error::InvalidAsciiString)?,
+        ))
+    }
+}
+
+impl TryFrom<ffi::CString> for CashBoxSize {
+    type Error = Error;
+
+    fn try_from(val: ffi::CString) -> Result<Self> {
+        val.as_c_str().try_into()
+    }
+}
+
+impl TryFrom<String> for CashBoxSize {
+    type Error = Error;
+
+    fn try_from(val: String) -> Result<Self> {
+        val.as_bytes().try_into()
+    }
+}
+
+impl TryFrom<&str> for CashBoxSize {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        val.as_bytes().try_into()
+    }
+}
+
+impl From<CashBoxSize> for String {
+    fn from(val: CashBoxSize) -> Self {
+        format!("{val}")
+    }
+}
+
+impl fmt::Display for CashBoxSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<CashBoxSize> for Vec<u8> {
+    fn from(val: CashBoxSize) -> Self {
+        val.into_string_with_nul().into_bytes()
+    }
+}
+
+impl From<&CashBoxSize> for Vec<u8> {
+    fn from(val: &CashBoxSize) -> Self {
+        (*val).into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cash_box_size() {
+        let raw = b"500\0";
+        let cstring = ffi::CString::from_vec_with_nul(raw.into()).unwrap();
+        let string = String::from_utf8(raw.into()).unwrap();
+        let exp = CashBoxSize::create(500);
+
+        assert_eq!(CashBoxSize::try_from(raw), Ok(exp));
+        assert_eq!(CashBoxSize::try_from(cstring.as_c_str()), Ok(exp));
+        assert_eq!(CashBoxSize::try_from(cstring), Ok(exp));
+        assert_eq!(CashBoxSize::try_from(string.as_str()), Ok(exp));
+        assert_eq!(exp.into_string_with_nul().as_str(), string.as_str());
+        assert_eq!(CashBoxSize::try_from(string), Ok(exp));
+
+        [1, 100, 500, 1000, 2000, 10_000]
+            .map(CashBoxSize::create)
+            .into_iter()
+            .for_each(|size| {
+                // check the string length is the digits + trailing nul byte
+                assert_eq!(size.into_string_with_nul().len(), size.len());
+            });
+    }
+
+    #[test]
+    fn test_cash_box_size_no_nul() {
+        let invalid = b"500";
+        let string = String::from_utf8(invalid.into()).unwrap();
+
+        assert!(CashBoxSize::try_from(invalid).is_err());
+        assert!(CashBoxSize::try_from(string.as_str()).is_err());
+        assert!(CashBoxSize::try_from(string).is_err());
+    }
+
+    #[test]
+    fn test_cash_box_size_not_a_number() {
+        let invalid = b"50note";
+        let string = String::from_utf8(invalid.into()).unwrap();
+        let cstring = ffi::CString::new(string.as_bytes()).unwrap();
+
+        assert!(CashBoxSize::try_from(invalid).is_err());
+        assert!(CashBoxSize::try_from(string.as_str()).is_err());
+        assert!(CashBoxSize::try_from(string).is_err());
+        assert!(CashBoxSize::try_from(cstring.as_c_str()).is_err());
+        assert!(CashBoxSize::try_from(cstring).is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod bill_acceptor_state;
+mod cash_box_size;
 mod currency;
 mod denomination;
 mod device_status;
@@ -19,6 +20,7 @@ mod unit_status;
 pub mod usb;
 
 pub use bill_acceptor_state::*;
+pub use cash_box_size::*;
 pub use currency::*;
 pub use denomination::*;
 pub use device_status::*;

--- a/src/message/request.rs
+++ b/src/message/request.rs
@@ -6,6 +6,7 @@ use crate::{
     Error, Message, MessageCode, MessageData, MessageType, RequestCode, RequestType, Result,
 };
 
+mod cash_box_size_request;
 mod collect_request;
 mod currency_assign_request;
 mod denomination_disable_request;
@@ -27,6 +28,7 @@ mod status_request;
 mod uid_request;
 mod version_request;
 
+pub use cash_box_size_request::*;
 pub use collect_request::*;
 pub use currency_assign_request::*;
 pub use denomination_disable_request::*;

--- a/src/message/request/cash_box_size_request.rs
+++ b/src/message/request/cash_box_size_request.rs
@@ -1,0 +1,245 @@
+use crate::{
+    Error, Message, MessageCode, MessageData, MessageType, RequestCode, RequestType, Result,
+};
+
+/// Represents a `Idle` request message.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CashBoxSizeRequest;
+
+impl CashBoxSizeRequest {
+    /// Creates a new [CashBoxSizeRequest].
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Gets the [MessageType] for the [CashBoxSizeRequest].
+    pub const fn message_type(&self) -> MessageType {
+        MessageType::Request(self.request_type())
+    }
+
+    /// Gets the [RequestType] for the [CashBoxSizeRequest].
+    pub const fn request_type(&self) -> RequestType {
+        RequestType::Status
+    }
+
+    /// Gets the [MessageCode] for the [CashBoxSizeRequest].
+    pub const fn message_code(&self) -> MessageCode {
+        MessageCode::Request(self.request_code())
+    }
+
+    /// Gets the [RequestCode] for the [CashBoxSizeRequest].
+    pub const fn request_code(&self) -> RequestCode {
+        RequestCode::CashBoxSize
+    }
+}
+
+impl Default for CashBoxSizeRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<CashBoxSizeRequest> for Message {
+    fn from(val: CashBoxSizeRequest) -> Self {
+        Message::new().with_data(val.into())
+    }
+}
+
+impl From<&CashBoxSizeRequest> for Message {
+    fn from(val: &CashBoxSizeRequest) -> Self {
+        (*val).into()
+    }
+}
+
+impl From<CashBoxSizeRequest> for MessageData {
+    fn from(val: CashBoxSizeRequest) -> Self {
+        Self::new()
+            .with_message_type(val.message_type())
+            .with_message_code(val.message_code())
+    }
+}
+
+impl From<&CashBoxSizeRequest> for MessageData {
+    fn from(val: &CashBoxSizeRequest) -> Self {
+        (*val).into()
+    }
+}
+
+impl TryFrom<&Message> for CashBoxSizeRequest {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        val.data().try_into()
+    }
+}
+
+impl TryFrom<Message> for CashBoxSizeRequest {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl TryFrom<&MessageData> for CashBoxSizeRequest {
+    type Error = Error;
+
+    fn try_from(val: &MessageData) -> Result<Self> {
+        const EXP_TYPE: MessageType = MessageType::Request(RequestType::Status);
+        const EXP_CODE: MessageCode = MessageCode::Request(RequestCode::CashBoxSize);
+
+        match (val.message_type(), val.message_code()) {
+            (EXP_TYPE, EXP_CODE) => Ok(Self),
+            (msg_type, msg_code) => Err(Error::InvalidMessage((
+                (msg_type.into(), msg_code.into()),
+                (EXP_TYPE.into(), EXP_CODE.into()),
+            ))),
+        }
+    }
+}
+
+impl TryFrom<MessageData> for CashBoxSizeRequest {
+    type Error = Error;
+
+    fn try_from(val: MessageData) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{EventCode, EventType};
+
+    #[test]
+    fn test_cash_box_size_request() -> Result<()> {
+        let exp_type = MessageType::Request(RequestType::Status);
+        let exp_code = MessageCode::Request(RequestCode::CashBoxSize);
+
+        let msg_data = MessageData::new()
+            .with_message_type(exp_type)
+            .with_message_code(exp_code);
+        let msg = Message::new().with_data(msg_data);
+
+        let exp_req = CashBoxSizeRequest::new();
+
+        assert_eq!(exp_req.message_type(), exp_type);
+        assert_eq!(exp_type.request_type(), Ok(exp_req.request_type()));
+
+        assert_eq!(exp_req.message_code(), exp_code);
+        assert_eq!(exp_code.request_code(), Ok(exp_req.request_code()));
+
+        assert_eq!(Message::from(exp_req), msg);
+        assert_eq!(CashBoxSizeRequest::try_from(&msg), Ok(exp_req));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cash_box_size_request_invalid() -> Result<()> {
+        let invalid_types = [MessageType::Reserved]
+            .into_iter()
+            .chain((0x80..=0x8f).map(|m| MessageType::Event(EventType::from_u8(m))))
+            .chain(
+                [
+                    RequestType::SetFeature,
+                    RequestType::Operation,
+                    RequestType::Reserved,
+                ]
+                .map(MessageType::Request),
+            )
+            .collect::<Vec<MessageType>>();
+
+        let invalid_codes = [
+            RequestCode::Uid,
+            RequestCode::ProgramSignature,
+            RequestCode::Version,
+            RequestCode::SerialNumber,
+            RequestCode::ModelName,
+            RequestCode::Status,
+            RequestCode::Stack,
+            RequestCode::Inhibit,
+            RequestCode::Collect,
+            RequestCode::Key,
+            RequestCode::EventResendInterval,
+            RequestCode::Reset,
+            RequestCode::Reject,
+            RequestCode::Hold,
+            RequestCode::AcceptorCollect,
+            RequestCode::DenominationDisable,
+            RequestCode::DirectionDisable,
+            RequestCode::CurrencyAssign,
+            RequestCode::Idle,
+            RequestCode::NearFull,
+            RequestCode::BarCode,
+            RequestCode::Insert,
+            RequestCode::ConditionalVend,
+            RequestCode::Pause,
+            RequestCode::NoteDataInfo,
+            RequestCode::RecyclerCollect,
+            RequestCode::Reserved,
+        ]
+        .map(MessageCode::Request)
+        .into_iter()
+        .chain(
+            [
+                EventCode::PowerUp,
+                EventCode::PowerUpAcceptor,
+                EventCode::PowerUpStacker,
+                EventCode::Inhibit,
+                EventCode::ProgramSignature,
+                EventCode::Rejected,
+                EventCode::Collected,
+                EventCode::Clear,
+                EventCode::OperationError,
+                EventCode::Failure,
+                EventCode::NoteStay,
+                EventCode::PowerUpAcceptorAccepting,
+                EventCode::PowerUpStackerAccepting,
+                EventCode::Escrow,
+                EventCode::VendValid,
+                EventCode::AcceptorRejected,
+                EventCode::Returned,
+                EventCode::AcceptorCollected,
+                EventCode::Insert,
+                EventCode::ConditionalVend,
+                EventCode::Pause,
+                EventCode::Resume,
+                EventCode::AcceptorClear,
+                EventCode::AcceptorOperationError,
+                EventCode::AcceptorFailure,
+                EventCode::AcceptorNoteStay,
+                EventCode::FunctionAbeyance,
+                EventCode::Reserved,
+            ]
+            .map(MessageCode::Event),
+        )
+        .collect::<Vec<MessageCode>>();
+
+        for &msg_type in invalid_types.iter() {
+            for &msg_code in invalid_codes.iter() {
+                let inval_data = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(msg_code);
+
+                let inval_type = MessageData::new()
+                    .with_message_type(msg_type)
+                    .with_message_code(CashBoxSizeRequest::new().message_code());
+
+                let inval_code = MessageData::new()
+                    .with_message_type(CashBoxSizeRequest::new().message_type())
+                    .with_message_code(msg_code);
+
+                for stack_data in [inval_data, inval_type, inval_code] {
+                    assert!(CashBoxSizeRequest::try_from(&stack_data).is_err());
+                    assert!(
+                        CashBoxSizeRequest::try_from(Message::new().with_data(stack_data)).is_err()
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/message/response.rs
+++ b/src/message/response.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 use crate::{Error, Message, Result};
 
+mod cash_box_size_response;
 mod currency_assign_response;
 mod denomination_disable_response;
 mod direction_disable_response;
@@ -16,6 +17,7 @@ mod status_response;
 mod uid_response;
 mod version_response;
 
+pub use cash_box_size_response::*;
 pub use currency_assign_response::*;
 pub use denomination_disable_response::*;
 pub use direction_disable_response::*;

--- a/src/message/response/cash_box_size_response.rs
+++ b/src/message/response/cash_box_size_response.rs
@@ -1,0 +1,294 @@
+use std::fmt;
+
+use crate::{CashBoxSize, Error, Message, Response, ResponseCode, Result};
+
+/// Represents the response to a [CashBoxSizeRequest](crate::CashBoxSizeRequest).
+#[repr(C)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CashBoxSizeResponse {
+    code: ResponseCode,
+    cash_box_size: CashBoxSize,
+}
+
+impl CashBoxSizeResponse {
+    /// Creates a new [CashBoxSizeResponse].
+    pub const fn new() -> Self {
+        Self {
+            code: ResponseCode::new(),
+            cash_box_size: CashBoxSize::new(),
+        }
+    }
+
+    /// Gets the [ResponseCode] for the [CashBoxSizeResponse].
+    pub const fn code(&self) -> ResponseCode {
+        self.code
+    }
+
+    /// Sets the [ResponseCode] for the [CashBoxSizeResponse].
+    pub fn set_code(&mut self, code: ResponseCode) {
+        self.code = code;
+    }
+
+    /// Builder function that sets the [ResponseCode] for the [CashBoxSizeResponse].
+    pub const fn with_code(self, code: ResponseCode) -> Self {
+        Self {
+            code,
+            cash_box_size: self.cash_box_size,
+        }
+    }
+
+    /// Gets the [CashBoxSize] for the [CashBoxSizeResponse].
+    pub const fn cash_box_size(&self) -> &CashBoxSize {
+        &self.cash_box_size
+    }
+
+    /// Sets the [CashBoxSize] for the [CashBoxSizeResponse].
+    pub fn set_cash_box_size(&mut self, cash_box_size: CashBoxSize) {
+        self.cash_box_size = cash_box_size;
+    }
+
+    /// Builder function that sets the [CashBoxSize] for the [CashBoxSizeResponse].
+    pub const fn with_cash_box_size(self, cash_box_size: CashBoxSize) -> Self {
+        Self {
+            code: self.code,
+            cash_box_size,
+        }
+    }
+
+    /// Gets the metadata length of the [CashBoxSizeResponse].
+    pub const fn meta_len() -> usize {
+        ResponseCode::len()
+    }
+
+    /// Gets the length of the [CashBoxSizeResponse].
+    pub fn len(&self) -> usize {
+        Self::meta_len() + self.cash_box_size.len()
+    }
+
+    /// Gets whether the [CashBoxSizeResponse] is empty.
+    pub fn is_empty(&self) -> bool {
+        self.code.is_empty() && self.cash_box_size.is_empty()
+    }
+
+    /// Attempts to convert a byte buffer into a [CashBoxSizeResponse].
+    pub fn from_bytes(buf: &[u8]) -> Result<Self> {
+        let meta_len = Self::meta_len();
+        let buf_len = buf.len();
+
+        Ok(Self {
+            code: buf
+                .first()
+                .copied()
+                .ok_or(Error::InvalidResponseLen((buf_len, meta_len)))?
+                .try_into()?,
+            cash_box_size: buf
+                .get(1..)
+                .ok_or(Error::InvalidResponseLen((buf_len, meta_len)))?
+                .try_into()?,
+        })
+    }
+
+    /// Converts the [CashBoxSizeResponse] into a byte iterator.
+    pub fn iter(&self) -> impl Iterator<Item = u8> + '_ {
+        [self.code.to_u8()].into_iter().chain(self.cash_box_size)
+    }
+
+    /// Attempts to convert the [CashBoxSizeResponse] into a byte buffer.
+    pub fn to_bytes(&self, buf: &mut [u8]) -> Result<()> {
+        let len = self.len();
+        let buf_len = buf.len();
+
+        if buf_len < len {
+            Err(Error::InvalidResponseLen((buf_len, len)))
+        } else {
+            buf.iter_mut()
+                .take(len)
+                .zip(self.iter())
+                .for_each(|(dst, src)| *dst = src);
+            Ok(())
+        }
+    }
+
+    /// Converts the [CashBoxSizeResponse] into a byte vector.
+    pub fn into_bytes(&self) -> Vec<u8> {
+        self.iter().collect()
+    }
+}
+
+impl TryFrom<&[u8]> for CashBoxSizeResponse {
+    type Error = Error;
+
+    fn try_from(val: &[u8]) -> Result<Self> {
+        Self::from_bytes(val)
+    }
+}
+
+impl<const N: usize> TryFrom<&[u8; N]> for CashBoxSizeResponse {
+    type Error = Error;
+
+    fn try_from(val: &[u8; N]) -> Result<Self> {
+        Self::from_bytes(val.as_ref())
+    }
+}
+
+impl<const N: usize> TryFrom<[u8; N]> for CashBoxSizeResponse {
+    type Error = Error;
+
+    fn try_from(val: [u8; N]) -> Result<Self> {
+        Self::from_bytes(val.as_ref())
+    }
+}
+
+impl From<&CashBoxSizeResponse> for Response {
+    fn from(val: &CashBoxSizeResponse) -> Self {
+        Self {
+            code: val.code,
+            additional: val.cash_box_size.into(),
+        }
+    }
+}
+
+impl From<CashBoxSizeResponse> for Response {
+    fn from(val: CashBoxSizeResponse) -> Self {
+        (&val).into()
+    }
+}
+
+impl TryFrom<&Response> for CashBoxSizeResponse {
+    type Error = Error;
+
+    fn try_from(val: &Response) -> Result<Self> {
+        match val.additional().len() {
+            0 => Ok(Self {
+                code: val.code,
+                cash_box_size: CashBoxSize::new(),
+            }),
+            _ => Ok(Self {
+                code: val.code,
+                cash_box_size: val.additional().try_into()?,
+            }),
+        }
+    }
+}
+
+impl TryFrom<Response> for CashBoxSizeResponse {
+    type Error = Error;
+
+    fn try_from(val: Response) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl From<&CashBoxSizeResponse> for Message {
+    fn from(val: &CashBoxSizeResponse) -> Self {
+        use crate::{CashBoxSizeRequest, MessageData};
+
+        MessageData::from(CashBoxSizeRequest::new())
+            .with_additional(val.into_bytes().as_ref())
+            .into()
+    }
+}
+
+impl From<CashBoxSizeResponse> for Message {
+    fn from(val: CashBoxSizeResponse) -> Self {
+        (&val).into()
+    }
+}
+
+impl TryFrom<&Message> for CashBoxSizeResponse {
+    type Error = Error;
+
+    fn try_from(val: &Message) -> Result<Self> {
+        Response::try_from(val)?.try_into()
+    }
+}
+
+impl TryFrom<Message> for CashBoxSizeResponse {
+    type Error = Error;
+
+    fn try_from(val: Message) -> Result<Self> {
+        (&val).try_into()
+    }
+}
+
+impl Default for CashBoxSizeResponse {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for CashBoxSizeResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{{")?;
+        write!(f, r#""code": {}, "#, self.code())?;
+        write!(f, r#""cash_box_size": {}"#, self.cash_box_size())?;
+        write!(f, "}}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cash_box_size_response() -> Result<()> {
+        let raw_code = ResponseCode::Ack as u8;
+        let raw_version = b"100\0";
+        let raw: Vec<u8> = [raw_code]
+            .into_iter()
+            .chain(raw_version.iter().cloned())
+            .collect();
+
+        let exp_version = CashBoxSize::try_from(raw_version.as_ref())?;
+
+        let exp = CashBoxSizeResponse::new()
+            .with_code(ResponseCode::Ack)
+            .with_cash_box_size(exp_version.clone());
+
+        let res = Response::new()
+            .with_code(ResponseCode::Ack)
+            .with_additional(raw_version.as_ref());
+
+        assert_eq!(CashBoxSizeResponse::from_bytes(raw.as_ref())?, exp);
+        assert_eq!(CashBoxSizeResponse::try_from(&res)?, exp);
+        assert_eq!(Response::from(&exp), res);
+
+        let out = exp.into_bytes();
+        assert_eq!(out, raw);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_cash_box_size_response_invalid() -> Result<()> {
+        let raw_code = ResponseCode::Ack as u8;
+        let good_vers = CashBoxSize::try_from(b"100\0")?;
+        let bad_vers = [
+            // no nul
+            b"100".as_ref(),
+            // invalid number
+            b"100S\0".as_ref(),
+            // no number
+            b"\0".as_ref(),
+        ];
+
+        let exp = CashBoxSizeResponse::new()
+            .with_code(ResponseCode::Ack)
+            .with_cash_box_size(good_vers.clone());
+
+        for ver in bad_vers.into_iter() {
+            let raw: Vec<u8> = [raw_code].into_iter().chain(ver.iter().cloned()).collect();
+            assert!(CashBoxSizeResponse::from_bytes(raw.as_ref()).is_err());
+            assert!(exp.to_bytes(&mut []).is_err());
+            assert!(CashBoxSizeResponse::try_from(Response::new().with_additional(ver)).is_err());
+            assert!(CashBoxSizeResponse::try_from(
+                Response::new()
+                    .with_code(ResponseCode::Ack)
+                    .with_additional(ver)
+            )
+            .is_err());
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Adds the `CashBoxSizeRequest` and `CashBoxSize` types to handle requests to get the device cash box size.

Adds the `CashBoxSizeResponse` type to represent responses to `CashBoxSizeRequest` messages.